### PR TITLE
Make sure forbidden-imports rule checks files directly inside layers

### DIFF
--- a/.changeset/quick-eggs-exist.md
+++ b/.changeset/quick-eggs-exist.md
@@ -1,0 +1,5 @@
+---
+'@feature-sliced/steiger-plugin': patch
+---
+
+Make sure forbidden-imports rule checks files directly inside layers

--- a/packages/steiger-plugin-fsd/src/_lib/index-source-files.ts
+++ b/packages/steiger-plugin-fsd/src/_lib/index-source-files.ts
@@ -31,7 +31,9 @@ export function indexSourceFiles(root: Folder): Record<string, SourceFile> {
     // Even though files that are directly inside a layer are not encouraged by the FSD and are forbidden in most cases
     // (except for an index/root file for the app layer as an entry point to the application), users can still add them.
     // So, we need to index all files directly inside a layer to find errors.
-    walk(layer, { layerName: layerName as LayerName, sliceName: null, segmentName: null })
+    layer.children
+      .filter((child) => child.type === 'file')
+      .forEach((file) => walk(file, { layerName: layerName as LayerName, sliceName: null, segmentName: null }))
 
     if (!isSliced(layer)) {
       for (const [segmentName, segment] of Object.entries(getSegments(layer))) {

--- a/packages/steiger-plugin-fsd/src/_lib/index-source-files.ts
+++ b/packages/steiger-plugin-fsd/src/_lib/index-source-files.ts
@@ -77,6 +77,11 @@ if (import.meta.vitest) {
             📄 EditorPage.tsx
             📄 Editor.tsx
           📄 index.ts
+      📂 app
+        📂 ui
+          📄 index.ts
+        📄 root.ts
+        📄 index.ts
     `)
 
     expect(indexSourceFiles(root)).toEqual({
@@ -168,6 +173,33 @@ if (import.meta.vitest) {
         },
         layerName: 'shared',
         segmentName: 'ui',
+        sliceName: null,
+      },
+      [joinFromRoot('app', 'ui', 'index.ts')]: {
+        file: {
+          path: joinFromRoot('app', 'ui', 'index.ts'),
+          type: 'file',
+        },
+        layerName: 'app',
+        segmentName: 'ui',
+        sliceName: null,
+      },
+      [joinFromRoot('app', 'root.ts')]: {
+        file: {
+          path: joinFromRoot('app', 'root.ts'),
+          type: 'file',
+        },
+        layerName: 'app',
+        segmentName: 'root',
+        sliceName: null,
+      },
+      [joinFromRoot('app', 'index.ts')]: {
+        file: {
+          path: joinFromRoot('app', 'index.ts'),
+          type: 'file',
+        },
+        layerName: 'app',
+        segmentName: null,
         sliceName: null,
       },
     })

--- a/packages/steiger-plugin-fsd/src/_lib/index-source-files.ts
+++ b/packages/steiger-plugin-fsd/src/_lib/index-source-files.ts
@@ -28,6 +28,11 @@ export function indexSourceFiles(root: Folder): Record<string, SourceFile> {
   }
 
   for (const [layerName, layer] of Object.entries(getLayers(root))) {
+    // Even though files that are directly inside a layer are not encouraged by the FSD and are forbidden in most cases
+    // (except for an index/root file for the app layer as an entry point to the application), users can still add them.
+    // So, we need to index all files directly inside a layer to find errors.
+    walk(layer, { layerName: layerName as LayerName, sliceName: null, segmentName: null })
+
     if (!isSliced(layer)) {
       for (const [segmentName, segment] of Object.entries(getSegments(layer))) {
         walk(segment, { layerName: layerName as LayerName, sliceName: null, segmentName })

--- a/packages/steiger-plugin-fsd/src/_lib/prepare-test.ts
+++ b/packages/steiger-plugin-fsd/src/_lib/prepare-test.ts
@@ -4,31 +4,11 @@ import type { FsdRoot } from '@feature-sliced/filesystem'
 import type { Folder, File, Diagnostic } from '@steiger/types'
 import { vi } from 'vitest'
 
-function findSubfolder(folder: Folder, path: string): Folder {
-  function checkFolder(folder: Folder): Folder {
-    if (folder.path === path) {
-      return folder
-    }
-
-    if (path.startsWith(folder.path)) {
-      for (const child of folder.children) {
-        if (child.type === 'folder') {
-          const result = checkFolder(child)
-          if (result) {
-            return result
-          }
-        }
-      }
-    }
-
-    throw new Error(`Path "${path}" not found in the provided file system mock!`)
-  }
-
-  return checkFolder(folder)
-}
-
-/** Parse a multi-line indented string with emojis for files and folders into an FSD root. */
-export function parseIntoFsdRoot(fsMarkup: string, rootPath?: string): FsdRoot {
+/** Parse a multi-line indented string with emojis for files and folders into an FSD root.
+ * @param fsMarkup - a file system tree represented in markup using file and folder emojis
+ * @param mountTo - virtually make the passed markup a subtree of the mountTo folder
+ * */
+export function parseIntoFsdRoot(fsMarkup: string, mountTo?: string): FsdRoot {
   function parseFolder(lines: Array<string>, path: string): Folder {
     const children: Array<Folder | File> = []
 
@@ -55,9 +35,8 @@ export function parseIntoFsdRoot(fsMarkup: string, rootPath?: string): FsdRoot {
     .filter(Boolean)
     .map((line, _i, lines) => line.slice(lines[0].search(/\S/)))
     .filter(Boolean)
-  const parsedFolder = parseFolder(lines, joinFromRoot())
 
-  return rootPath ? findSubfolder(parsedFolder, rootPath) : parsedFolder
+  return parseFolder(lines, mountTo ?? joinFromRoot())
 }
 
 export function compareMessages(a: Diagnostic, b: Diagnostic): number {
@@ -176,78 +155,81 @@ if (import.meta.vitest) {
 
   test('it should return a nested root folder when the optional rootPath argument is passed', () => {
     const markup = `
-      📂 src
-        📂 entities
-          📂 users
-            📂 ui
-            📄 index.ts
-          📂 posts
-            📂 ui
-            📄 index.ts
-        📂 shared
+      📂 entities
+        📂 users
           📂 ui
-            📄 index.ts
-            📄 Button.tsx
+          📄 index.ts
+        📂 posts
+          📂 ui
+          📄 index.ts
+      📂 shared
+        📂 ui
+          📄 index.ts
+          📄 Button.tsx
     `
-    const root = parseIntoFsdRoot(markup, joinFromRoot('src', 'entities'))
+    const root = parseIntoFsdRoot(markup, joinFromRoot('src'))
 
     expect(root).toEqual({
       type: 'folder',
-      path: joinFromRoot('src', 'entities'),
+      path: joinFromRoot('src'),
       children: [
         {
           type: 'folder',
-          path: joinFromRoot('src', 'entities', 'users'),
+          path: joinFromRoot('src', 'entities'),
           children: [
             {
               type: 'folder',
-              path: joinFromRoot('src', 'entities', 'users', 'ui'),
-              children: [],
+              path: joinFromRoot('src', 'entities', 'users'),
+              children: [
+                {
+                  type: 'folder',
+                  path: joinFromRoot('src', 'entities', 'users', 'ui'),
+                  children: [],
+                },
+                {
+                  type: 'file',
+                  path: joinFromRoot('src', 'entities', 'users', 'index.ts'),
+                },
+              ],
             },
             {
-              type: 'file',
-              path: joinFromRoot('src', 'entities', 'users', 'index.ts'),
+              type: 'folder',
+              path: joinFromRoot('src', 'entities', 'posts'),
+              children: [
+                {
+                  type: 'folder',
+                  path: joinFromRoot('src', 'entities', 'posts', 'ui'),
+                  children: [],
+                },
+                {
+                  type: 'file',
+                  path: joinFromRoot('src', 'entities', 'posts', 'index.ts'),
+                },
+              ],
             },
           ],
         },
         {
           type: 'folder',
-          path: joinFromRoot('src', 'entities', 'posts'),
+          path: joinFromRoot('src', 'shared'),
           children: [
             {
               type: 'folder',
-              path: joinFromRoot('src', 'entities', 'posts', 'ui'),
-              children: [],
-            },
-            {
-              type: 'file',
-              path: joinFromRoot('src', 'entities', 'posts', 'index.ts'),
+              path: joinFromRoot('src', 'shared', 'ui'),
+              children: [
+                {
+                  type: 'file',
+                  path: joinFromRoot('src', 'shared', 'ui', 'index.ts'),
+                },
+                {
+                  type: 'file',
+                  path: joinFromRoot('src', 'shared', 'ui', 'Button.tsx'),
+                },
+              ],
             },
           ],
         },
       ],
     })
-  })
-
-  test('it should throw an error when the path (from rootPath argument) is not found in the provided file system mock', () => {
-    const markup = `
-      📂 src
-        📂 entities
-          📂 users
-            📂 ui
-            📄 index.ts
-          📂 posts
-            📂 ui
-            📄 index.ts
-        📂 shared
-          📂 ui
-            📄 index.ts
-            📄 Button.tsx
-    `
-    const nonExistentPath = joinFromRoot('src', 'non-existent-folder')
-
-    expect(() => parseIntoFsdRoot(markup, nonExistentPath)).toThrowError(
-      `Path "${nonExistentPath}" not found in the provided file system mock!`,
-    )
   })
 }

--- a/packages/steiger-plugin-fsd/src/_lib/prepare-test.ts
+++ b/packages/steiger-plugin-fsd/src/_lib/prepare-test.ts
@@ -244,8 +244,10 @@ if (import.meta.vitest) {
             📄 index.ts
             📄 Button.tsx
     `
-    expect(() => parseIntoFsdRoot(markup, joinFromRoot('src', 'non-existent-folder'))).toThrowError(
-      'Path "/src/non-existent-folder" not found in the provided file system mock!',
+    const nonExistentPath = joinFromRoot('src', 'non-existent-folder')
+
+    expect(() => parseIntoFsdRoot(markup, nonExistentPath)).toThrowError(
+      `Path "${nonExistentPath}" not found in the provided file system mock!`,
     )
   })
 }

--- a/packages/steiger-plugin-fsd/src/forbidden-imports/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/forbidden-imports/index.spec.ts
@@ -72,7 +72,7 @@ it('reports no errors on a project with only correct imports', async () => {
           📄 index.ts
   `)
 
-  expect((await forbiddenImports.check(root)).diagnostics).toEqual([])
+  expect((await forbiddenImports.check(root.children[0] as Folder)).diagnostics).toEqual([])
 })
 
 it('reports errors on a project with cross-imports in entities', async () => {

--- a/packages/steiger-plugin-fsd/src/forbidden-imports/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/forbidden-imports/index.spec.ts
@@ -57,19 +57,18 @@ vi.mock('node:fs', async (importOriginal) => {
 it('reports no errors on a project with only correct imports', async () => {
   const root = parseIntoFsdRoot(
     `
-      📂 src
-        📂 shared
+      📂 shared
+        📂 ui
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 pages
+        📂 editor
           📂 ui
-            📄 styles.ts
-            📄 Button.tsx
-            📄 TextField.tsx
-            📄 index.ts
-        📂 pages
-          📂 editor
-            📂 ui
-              📄 EditorPage.tsx
-              📄 Editor.tsx
-            📄 index.ts
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
     `,
     joinFromRoot('src'),
   )
@@ -80,28 +79,27 @@ it('reports no errors on a project with only correct imports', async () => {
 it('reports errors on a project with cross-imports in entities', async () => {
   const root = parseIntoFsdRoot(
     `
-      📂 src
-        📂 shared
+      📂 shared
+        📂 ui
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 user
           📂 ui
-            📄 styles.ts
-            📄 Button.tsx
-            📄 TextField.tsx
-            📄 index.ts
-        📂 entities
-          📂 user
-            📂 ui
-              📄 UserAvatar.tsx
-            📄 index.ts
-          📂 product
-            📂 ui
-              📄 ProductCard.tsx
-            📄 index.ts
-        📂 pages
-          📂 editor
-            📂 ui
-              📄 EditorPage.tsx
-              📄 Editor.tsx
-            📄 index.ts
+            📄 UserAvatar.tsx
+          📄 index.ts
+        📂 product
+          📂 ui
+            📄 ProductCard.tsx
+          📄 index.ts
+      📂 pages
+        📂 editor
+          📂 ui
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
     `,
     joinFromRoot('src'),
   )
@@ -117,25 +115,24 @@ it('reports errors on a project with cross-imports in entities', async () => {
 it('reports errors on a project where a feature imports from a page', async () => {
   const root = parseIntoFsdRoot(
     `
-      📂 src
-        📂 shared
+      📂 shared
+        📂 ui
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 features
+        📂 comments
+          📂 ui
+            📄 CommentCard.tsx
+          📄 index.ts
+      📂 pages
+        📂 editor
           📂 ui
             📄 styles.ts
-            📄 Button.tsx
-            📄 TextField.tsx
-            📄 index.ts
-        📂 features
-          📂 comments
-            📂 ui
-              📄 CommentCard.tsx
-            📄 index.ts
-        📂 pages
-          📂 editor
-            📂 ui
-              📄 styles.ts
-              📄 EditorPage.tsx
-              📄 Editor.tsx
-            📄 index.ts
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
     `,
     joinFromRoot('src'),
   )
@@ -151,33 +148,32 @@ it('reports errors on a project where a feature imports from a page', async () =
 it('reports errors in a project where a lower level imports from files that are direct children of a higher level', async () => {
   const root = parseIntoFsdRoot(
     `
-      📂 src
-        📂 shared
+      📂 shared
+        📂 ui
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 cart
+          📄 index.ts
+          📂 lib
+            📄 count-cart-items.ts
+            📄 index.ts
+          📂 ui
+            📄 SmallCart.tsx
+      📂 pages
+        📂 editor
           📂 ui
             📄 styles.ts
-            📄 Button.tsx
-            📄 TextField.tsx
-            📄 index.ts
-        📂 entities
-          📂 cart
-            📄 index.ts
-            📂 lib
-              📄 count-cart-items.ts
-              📄 index.ts
-            📂 ui
-              📄 SmallCart.tsx
-        📂 pages
-          📂 editor
-            📂 ui
-              📄 styles.ts
-              📄 EditorPage.tsx
-              📄 Editor.tsx
-            📄 index.ts
-        📂 app
-          📂 ui
-            📄 index.ts
+            📄 EditorPage.tsx
+            📄 Editor.tsx
           📄 index.ts
-          📄 root.ts
+      📂 app
+        📂 ui
+          📄 index.ts
+        📄 index.ts
+        📄 root.ts
     `,
     joinFromRoot('src'),
   )

--- a/packages/steiger-plugin-fsd/src/forbidden-imports/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/forbidden-imports/index.spec.ts
@@ -1,5 +1,4 @@
 import { expect, it, vi } from 'vitest'
-import { Folder } from '@steiger/types'
 
 import { joinFromRoot, parseIntoFsdRoot } from '../_lib/prepare-test.js'
 import forbiddenImports from './index.js'
@@ -56,52 +55,58 @@ vi.mock('node:fs', async (importOriginal) => {
 })
 
 it('reports no errors on a project with only correct imports', async () => {
-  const root = parseIntoFsdRoot(`
-    📂 src
-      📂 shared
-        📂 ui
-          📄 styles.ts
-          📄 Button.tsx
-          📄 TextField.tsx
-          📄 index.ts
-      📂 pages
-        📂 editor
+  const root = parseIntoFsdRoot(
+    `
+      📂 src
+        📂 shared
           📂 ui
-            📄 EditorPage.tsx
-            📄 Editor.tsx
-          📄 index.ts
-  `)
+            📄 styles.ts
+            📄 Button.tsx
+            📄 TextField.tsx
+            📄 index.ts
+        📂 pages
+          📂 editor
+            📂 ui
+              📄 EditorPage.tsx
+              📄 Editor.tsx
+            📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
 
-  expect((await forbiddenImports.check(root.children[0] as Folder)).diagnostics).toEqual([])
+  expect((await forbiddenImports.check(root)).diagnostics).toEqual([])
 })
 
 it('reports errors on a project with cross-imports in entities', async () => {
-  const root = parseIntoFsdRoot(`
-    📂 src
-      📂 shared
-        📂 ui
-          📄 styles.ts
-          📄 Button.tsx
-          📄 TextField.tsx
-          📄 index.ts
-      📂 entities
-        📂 user
+  const root = parseIntoFsdRoot(
+    `
+      📂 src
+        📂 shared
           📂 ui
-            📄 UserAvatar.tsx
-          📄 index.ts
-        📂 product
-          📂 ui
-            📄 ProductCard.tsx
-          📄 index.ts
-      📂 pages
-        📂 editor
-          📂 ui
-            📄 EditorPage.tsx
-            📄 Editor.tsx
-          📄 index.ts
-  `)
+            📄 styles.ts
+            📄 Button.tsx
+            📄 TextField.tsx
+            📄 index.ts
+        📂 entities
+          📂 user
+            📂 ui
+              📄 UserAvatar.tsx
+            📄 index.ts
+          📂 product
+            📂 ui
+              📄 ProductCard.tsx
+            📄 index.ts
+        📂 pages
+          📂 editor
+            📂 ui
+              📄 EditorPage.tsx
+              📄 Editor.tsx
+            📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
 
-  expect((await forbiddenImports.check(root.children[0] as Folder)).diagnostics).toEqual([
+  expect((await forbiddenImports.check(root)).diagnostics).toEqual([
     {
       message: `Forbidden cross-import from slice "user".`,
       location: { path: joinFromRoot('src', 'entities', 'product', 'ui', 'ProductCard.tsx') },
@@ -110,29 +115,32 @@ it('reports errors on a project with cross-imports in entities', async () => {
 })
 
 it('reports errors on a project where a feature imports from a page', async () => {
-  const root = parseIntoFsdRoot(`
-    📂 src
-      📂 shared
-        📂 ui
-          📄 styles.ts
-          📄 Button.tsx
-          📄 TextField.tsx
-          📄 index.ts
-      📂 features
-        📂 comments
-          📂 ui
-            📄 CommentCard.tsx
-          📄 index.ts
-      📂 pages
-        📂 editor
+  const root = parseIntoFsdRoot(
+    `
+      📂 src
+        📂 shared
           📂 ui
             📄 styles.ts
-            📄 EditorPage.tsx
-            📄 Editor.tsx
-          📄 index.ts
-  `)
+            📄 Button.tsx
+            📄 TextField.tsx
+            📄 index.ts
+        📂 features
+          📂 comments
+            📂 ui
+              📄 CommentCard.tsx
+            📄 index.ts
+        📂 pages
+          📂 editor
+            📂 ui
+              📄 styles.ts
+              📄 EditorPage.tsx
+              📄 Editor.tsx
+            📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
 
-  expect((await forbiddenImports.check(root.children[0] as Folder)).diagnostics.sort()).toEqual([
+  expect((await forbiddenImports.check(root)).diagnostics.sort()).toEqual([
     {
       message: `Forbidden import from higher layer "pages".`,
       location: { path: joinFromRoot('src', 'features', 'comments', 'ui', 'CommentCard.tsx') },
@@ -141,37 +149,40 @@ it('reports errors on a project where a feature imports from a page', async () =
 })
 
 it('reports errors in a project where a lower level imports from files that are direct children of a higher level', async () => {
-  const root = parseIntoFsdRoot(`
-    📂 src
-      📂 shared
-        📂 ui
-          📄 styles.ts
-          📄 Button.tsx
-          📄 TextField.tsx
-          📄 index.ts
-      📂 entities
-        📂 cart
-          📄 index.ts
-          📂 lib
-            📄 count-cart-items.ts
-            📄 index.ts
-          📂 ui
-            📄 SmallCart.tsx
-      📂 pages
-        📂 editor
+  const root = parseIntoFsdRoot(
+    `
+      📂 src
+        📂 shared
           📂 ui
             📄 styles.ts
-            📄 EditorPage.tsx
-            📄 Editor.tsx
+            📄 Button.tsx
+            📄 TextField.tsx
+            📄 index.ts
+        📂 entities
+          📂 cart
+            📄 index.ts
+            📂 lib
+              📄 count-cart-items.ts
+              📄 index.ts
+            📂 ui
+              📄 SmallCart.tsx
+        📂 pages
+          📂 editor
+            📂 ui
+              📄 styles.ts
+              📄 EditorPage.tsx
+              📄 Editor.tsx
+            📄 index.ts
+        📂 app
+          📂 ui
+            📄 index.ts
           📄 index.ts
-      📂 app
-        📂 ui
-          📄 index.ts
-        📄 index.ts
-        📄 root.ts
-  `)
+          📄 root.ts
+    `,
+    joinFromRoot('src'),
+  )
 
-  const diagnostics = (await forbiddenImports.check(root.children[0] as Folder)).diagnostics
+  const diagnostics = (await forbiddenImports.check(root)).diagnostics
   expect(diagnostics).toEqual([
     {
       message: `Forbidden import from higher layer "app".`,

--- a/packages/steiger-plugin-fsd/src/forbidden-imports/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/forbidden-imports/index.spec.ts
@@ -1,4 +1,5 @@
 import { expect, it, vi } from 'vitest'
+import { Folder } from '@steiger/types'
 
 import { joinFromRoot, parseIntoFsdRoot } from '../_lib/prepare-test.js'
 import forbiddenImports from './index.js'
@@ -6,7 +7,18 @@ import forbiddenImports from './index.js'
 vi.mock('tsconfck', async (importOriginal) => {
   return {
     ...(await importOriginal<typeof import('tsconfck')>()),
-    parse: vi.fn(() => Promise.resolve({ tsconfig: { compilerOptions: { paths: { '@/*': ['/*'] } } } })),
+    parse: vi.fn(() =>
+      Promise.resolve({
+        tsconfig: {
+          compilerOptions: {
+            baseUrl: '/src/',
+            paths: {
+              '@/*': ['./*'],
+            },
+          },
+        },
+      }),
+    ),
   }
 })
 
@@ -16,20 +28,28 @@ vi.mock('node:fs', async (importOriginal) => {
 
   return createFsMocks(
     {
-      '/shared/ui/styles.ts': '',
-      '/shared/ui/Button.tsx': 'import styles from "./styles";',
-      '/shared/ui/TextField.tsx': 'import styles from "./styles";',
-      '/shared/ui/index.ts': '',
-      '/entities/user/ui/UserAvatar.tsx': 'import { Button } from "@/shared/ui"',
-      '/entities/user/index.ts': '',
-      '/entities/product/ui/ProductCard.tsx': 'import { UserAvatar } from "@/entities/user"',
-      '/entities/product/index.ts': '',
-      '/features/comments/ui/CommentCard.tsx': 'import { styles } from "@/pages/editor"',
-      '/features/comments/index.ts': '',
-      '/pages/editor/ui/styles.ts': '',
-      '/pages/editor/ui/EditorPage.tsx': 'import { Button } from "@/shared/ui"; import { Editor } from "./Editor"',
-      '/pages/editor/ui/Editor.tsx': 'import { TextField } from "@/shared/ui"',
-      '/pages/editor/index.ts': '',
+      '/src/shared/ui/styles.ts': '',
+      '/src/shared/ui/Button.tsx': 'import styles from "./styles";',
+      '/src/shared/ui/TextField.tsx': 'import styles from "./styles";',
+      '/src/shared/ui/index.ts': '',
+      '/src/entities/user/ui/UserAvatar.tsx': 'import { Button } from "@/shared/ui"',
+      '/src/entities/user/index.ts': '',
+      '/src/entities/product/ui/ProductCard.tsx': 'import { UserAvatar } from "@/entities/user"',
+      '/src/entities/product/index.ts': '',
+      '/src/entities/cart/ui/SmallCart.tsx': 'import { App } from "@/app"',
+      '/src/entities/cart/lib/count-cart-items.ts': 'import root from "@/app/root.ts"',
+      '/src/entities/cart/lib/index.ts': '',
+      '/src/entities/cart/index.ts': '',
+      '/src/features/comments/ui/CommentCard.tsx': 'import { styles } from "@/pages/editor"',
+      '/src/features/comments/index.ts': '',
+      '/src/pages/editor/ui/styles.ts': '',
+      '/src/pages/editor/ui/EditorPage.tsx': 'import { Button } from "@/shared/ui"; import { Editor } from "./Editor"',
+      '/src/pages/editor/ui/Editor.tsx': 'import { TextField } from "@/shared/ui"',
+      '/src/pages/editor/index.ts': '',
+      '/src/app': '',
+      '/src/app/ui/index.ts': '',
+      '/src/app/index.ts': '',
+      '/src/app/root.ts': '',
     },
     originalFs,
   )
@@ -37,18 +57,19 @@ vi.mock('node:fs', async (importOriginal) => {
 
 it('reports no errors on a project with only correct imports', async () => {
   const root = parseIntoFsdRoot(`
-    📂 shared
-      📂 ui
-        📄 styles.ts
-        📄 Button.tsx
-        📄 TextField.tsx
-        📄 index.ts
-    📂 pages
-      📂 editor
+    📂 src
+      📂 shared
         📂 ui
-          📄 EditorPage.tsx
-          📄 Editor.tsx
-        📄 index.ts
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 pages
+        📂 editor
+          📂 ui
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
   `)
 
   expect((await forbiddenImports.check(root)).diagnostics).toEqual([])
@@ -56,63 +77,109 @@ it('reports no errors on a project with only correct imports', async () => {
 
 it('reports errors on a project with cross-imports in entities', async () => {
   const root = parseIntoFsdRoot(`
-    📂 shared
-      📂 ui
-        📄 styles.ts
-        📄 Button.tsx
-        📄 TextField.tsx
-        📄 index.ts
-    📂 entities
-      📂 user
+    📂 src
+      📂 shared
         📂 ui
-          📄 UserAvatar.tsx
-        📄 index.ts
-      📂 product
-        📂 ui
-          📄 ProductCard.tsx
-        📄 index.ts
-    📂 pages
-      📂 editor
-        📂 ui
-          📄 EditorPage.tsx
-          📄 Editor.tsx
-        📄 index.ts
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 user
+          📂 ui
+            📄 UserAvatar.tsx
+          📄 index.ts
+        📂 product
+          📂 ui
+            📄 ProductCard.tsx
+          📄 index.ts
+      📂 pages
+        📂 editor
+          📂 ui
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
   `)
 
-  expect((await forbiddenImports.check(root)).diagnostics).toEqual([
+  expect((await forbiddenImports.check(root.children[0] as Folder)).diagnostics).toEqual([
     {
       message: `Forbidden cross-import from slice "user".`,
-      location: { path: joinFromRoot('entities', 'product', 'ui', 'ProductCard.tsx') },
+      location: { path: joinFromRoot('src', 'entities', 'product', 'ui', 'ProductCard.tsx') },
     },
   ])
 })
 
 it('reports errors on a project where a feature imports from a page', async () => {
   const root = parseIntoFsdRoot(`
-    📂 shared
-      📂 ui
-        📄 styles.ts
-        📄 Button.tsx
-        📄 TextField.tsx
-        📄 index.ts
-    📂 features
-      📂 comments
-        📂 ui
-          📄 CommentCard.tsx
-        📄 index.ts
-    📂 pages
-      📂 editor
+    📂 src
+      📂 shared
         📂 ui
           📄 styles.ts
-          📄 EditorPage.tsx
-          📄 Editor.tsx
-        📄 index.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 features
+        📂 comments
+          📂 ui
+            📄 CommentCard.tsx
+          📄 index.ts
+      📂 pages
+        📂 editor
+          📂 ui
+            📄 styles.ts
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
   `)
 
-  expect((await forbiddenImports.check(root)).diagnostics).toEqual([
+  expect((await forbiddenImports.check(root.children[0] as Folder)).diagnostics.sort()).toEqual([
     {
       message: `Forbidden import from higher layer "pages".`,
-      location: { path: joinFromRoot('features', 'comments', 'ui', 'CommentCard.tsx') },
+      location: { path: joinFromRoot('src', 'features', 'comments', 'ui', 'CommentCard.tsx') },
+    },
+  ])
+})
+
+it('reports errors in a project where a lower level imports from files that are direct children of a higher level', async () => {
+  const root = parseIntoFsdRoot(`
+    📂 src
+      📂 shared
+        📂 ui
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 cart
+          📄 index.ts
+          📂 lib
+            📄 count-cart-items.ts
+            📄 index.ts
+          📂 ui
+            📄 SmallCart.tsx
+      📂 pages
+        📂 editor
+          📂 ui
+            📄 styles.ts
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
+      📂 app
+        📂 ui
+          📄 index.ts
+        📄 index.ts
+        📄 root.ts
+  `)
+
+  const diagnostics = (await forbiddenImports.check(root.children[0] as Folder)).diagnostics
+  expect(diagnostics).toEqual([
+    {
+      message: `Forbidden import from higher layer "app".`,
+      location: { path: joinFromRoot('src', 'entities', 'cart', 'lib', 'count-cart-items.ts') },
+    },
+    {
+      message: `Forbidden import from higher layer "app".`,
+      location: { path: joinFromRoot('src', 'entities', 'cart', 'ui', 'SmallCart.tsx') },
     },
   ])
 })

--- a/packages/steiger-plugin-fsd/src/forbidden-imports/index.ts
+++ b/packages/steiger-plugin-fsd/src/forbidden-imports/index.ts
@@ -1,12 +1,11 @@
 import * as fs from 'node:fs'
 import { layerSequence, resolveImport } from '@feature-sliced/filesystem'
 import precinct from 'precinct'
+const { paperwork } = precinct
 import { parse as parseNearestTsConfig } from 'tsconfck'
 import type { Diagnostic, Rule } from '@steiger/types'
 
 import { indexSourceFiles } from '../_lib/index-source-files.js'
-
-const { paperwork } = precinct
 
 const forbiddenImports = {
   name: 'forbidden-imports',

--- a/packages/steiger-plugin-fsd/src/forbidden-imports/index.ts
+++ b/packages/steiger-plugin-fsd/src/forbidden-imports/index.ts
@@ -1,11 +1,12 @@
 import * as fs from 'node:fs'
 import { layerSequence, resolveImport } from '@feature-sliced/filesystem'
 import precinct from 'precinct'
-const { paperwork } = precinct
 import { parse as parseNearestTsConfig } from 'tsconfck'
 import type { Diagnostic, Rule } from '@steiger/types'
 
 import { indexSourceFiles } from '../_lib/index-source-files.js'
+
+const { paperwork } = precinct
 
 const forbiddenImports = {
   name: 'forbidden-imports',


### PR DESCRIPTION
Resolves #49 

Had to move all layers into the /src folder for the mock filesystem used in the unit tests for the rule because there was an edge case where ts.resolveModuleName could not correctly resolve aliases for folders that are directly at the root of the filesystem (it did not resolve /app/index.ts from @/app and same problem for all layers). After moving everything in /src, they resolve just fine. I thought about creating an issue in TS repository, but it seems like an extremely rare edge case that nobody would care about. No one puts their real projects in the root of the file system.