### PR TITLE
Implement distinctions between warning and error diagnostics

### DIFF
--- a/packages/pretty-reporter/src/format-single-diagnostic.ts
+++ b/packages/pretty-reporter/src/format-single-diagnostic.ts
@@ -6,7 +6,8 @@ import chalk from 'chalk'
 import type { AugmentedDiagnostic } from './types.js'
 
 export function formatSingleDiagnostic(d: AugmentedDiagnostic, cwd: string): string {
-  const x = chalk.red(figures.cross)
+  const severityColor = d.severity === 'warn' ? chalk.yellow : chalk.red
+  const x = severityColor(figures.cross)
   const s = chalk.reset(figures.lineDownRight)
   const bar = chalk.reset(figures.lineVertical)
   const e = chalk.reset(figures.lineUpRight)

--- a/packages/pretty-reporter/src/index.ts
+++ b/packages/pretty-reporter/src/index.ts
@@ -10,7 +10,14 @@ export function formatPretty(diagnostics: Array<AugmentedDiagnostic>, cwd: strin
     return chalk.green(`${figures.tick} No problems found!`)
   }
 
-  let footer = chalk.red.bold(`Found ${diagnostics.length} problem${s(diagnostics.length)}`)
+  const errors = diagnostics.filter((d) => d.severity === 'error')
+  const warnings = diagnostics.filter((d) => d.severity === 'warn')
+
+  let footer = chalk.red.bold(`Found ${errors.length} error${s(errors.length)}`)
+
+  if (warnings.length > 0) {
+    footer += ` and ${chalk.yellow.bold(`${warnings.length} warning${s(warnings.length)}`)}`
+  }
 
   const autofixable = diagnostics.filter((d) => (d.fixes?.length ?? 0) > 0)
   if (autofixable.length === diagnostics.length) {

--- a/packages/steiger/src/cli.ts
+++ b/packages/steiger/src/cli.ts
@@ -28,6 +28,11 @@ const yargsProgram = yargs(hideBin(process.argv))
     describe: 'apply auto-fixes',
     type: 'boolean',
   })
+  .option('fail-on-warnings', {
+    demandOption: false,
+    describe: 'exit with an error code if there are warnings',
+    type: 'boolean',
+  })
   .string('_')
   .check((argv) => {
     const filePaths = argv._
@@ -86,6 +91,9 @@ if (consoleArgs.watch) {
   }
 
   if (stillRelevantDiagnostics.length > 0) {
-    process.exit(1)
+    const onlyWarnings = stillRelevantDiagnostics.every(d => d.severity === 'warn')
+    if (consoleArgs['fail-on-warnings'] || !onlyWarnings) {
+      process.exit(1)
+    }
   }
 }

--- a/packages/steiger/src/models/config.ts
+++ b/packages/steiger/src/models/config.ts
@@ -52,7 +52,7 @@ function buildValidationScheme(rules: Array<Rule>) {
 
   return z.object({
     // zod.record requires at least one element in the array, so we need "as [string, ...string[]]"
-    rules: z.record(z.enum(ruleNames as [string, ...string[]]), z.enum(['off', 'error'])).refine(
+    rules: z.record(z.enum(ruleNames as [string, ...string[]]), z.enum(['off', 'error', 'warn'])).refine(
       (value) => {
         const ruleNames = Object.keys(value)
         const offRules = ruleNames.filter((name) => value[name] === 'off')

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -61,8 +61,7 @@ export type Fix =
 
 export type Config = Array<ConfigObject | Plugin>
 
-// TODO: 'warn' is not supported yet, add it when it is
-export type Severity = 'off' | 'error'
+export type Severity = 'off' | 'error' | 'warn'
 
 export interface ConfigObject {
   /** Globs of files to check */


### PR DESCRIPTION
Related to #70

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/feature-sliced/steiger/issues/70?shareId=c3368814-0bd6-446f-8023-9b1028c9a2b7).