### PR TITLE
Implement inclusion/exclusion operators on VFS

### DIFF
--- a/.changeset/quick-timers-matter.md
+++ b/.changeset/quick-timers-matter.md
@@ -1,0 +1,5 @@
+---
+'steiger': minor
+---
+
+Implement the inclusion/exclusion operators on VFS

--- a/packages/steiger/package.json
+++ b/packages/steiger/package.json
@@ -46,6 +46,7 @@
     "effector": "^23.2.1",
     "globby": "^14.0.1",
     "immer": "^10.1.1",
+    "minimatch": "^10.0.1",
     "patronum": "^2.2.0",
     "prexit": "^2.2.0",
     "yargs": "^17.7.2",

--- a/packages/steiger/src/_lib/prepare-test.ts
+++ b/packages/steiger/src/_lib/prepare-test.ts
@@ -1,0 +1,235 @@
+import { join, sep } from 'node:path'
+import type { readFileSync, existsSync } from 'node:fs'
+import type { FsdRoot } from '@feature-sliced/filesystem'
+import type { Folder, File, Diagnostic } from '@steiger/types'
+import { vi } from 'vitest'
+
+/** Parse a multi-line indented string with emojis for files and folders into an FSD root.
+ * @param fsMarkup - a file system tree represented in markup using file and folder emojis
+ * @param mountTo - virtually make the passed markup a subtree of the mountTo folder
+ * */
+export function parseIntoFsdRoot(fsMarkup: string, mountTo?: string): FsdRoot {
+  function parseFolder(lines: Array<string>, path: string): Folder {
+    const children: Array<Folder | File> = []
+
+    lines.forEach((line, index) => {
+      if (line.startsWith('📂 ')) {
+        let nestedLines = lines.slice(index + 1)
+        const nextIndex = nestedLines.findIndex((line) => !line.startsWith('  '))
+        nestedLines = nestedLines.slice(0, nextIndex === -1 ? nestedLines.length : nextIndex)
+        const folder = parseFolder(
+          nestedLines.map((line) => line.slice('  '.length)),
+          join(path, line.slice('📂 '.length)),
+        )
+        children.push(folder)
+      } else if (line.startsWith('📄 ')) {
+        children.push({ type: 'file', path: join(path, line.slice('📄 '.length)) })
+      }
+    })
+
+    return { type: 'folder', path, children }
+  }
+
+  const lines = fsMarkup
+    .split('\n')
+    .filter(Boolean)
+    .map((line, _i, lines) => line.slice(lines[0].search(/\S/)))
+    .filter(Boolean)
+
+  return parseFolder(lines, mountTo ?? joinFromRoot())
+}
+
+export function compareMessages(a: Diagnostic, b: Diagnostic): number {
+  return a.message.localeCompare(b.message) || a.location.path.localeCompare(b.location.path)
+}
+
+export function joinFromRoot(...segments: Array<string>) {
+  return join('/', ...segments)
+}
+
+export function createFsMocks(mockedFiles: Record<string, string>, original: typeof import('fs')): typeof import('fs') {
+  const normalizedMockedFiles = Object.fromEntries(
+    Object.entries(mockedFiles).map(([path, content]) => [path.replace(/\//g, sep), content]),
+  )
+
+  return {
+    ...original,
+    readFileSync: vi.fn(((path, options) => {
+      const normalizedPath = typeof path === 'string' ? path.replace(/\//g, sep) : path
+      if (typeof normalizedPath === 'string' && normalizedPath in normalizedMockedFiles) {
+        return normalizedMockedFiles[normalizedPath as keyof typeof normalizedMockedFiles]
+      } else {
+        return original.readFileSync(normalizedPath, options)
+      }
+    }) as typeof readFileSync),
+    existsSync: vi.fn(((path) => {
+      const normalizedPath = typeof path === 'string' ? path.replace(/\//g, sep) : path
+      return Object.keys(normalizedMockedFiles).some(
+        (key) => key === normalizedPath || key.startsWith(normalizedPath + sep),
+      )
+    }) as typeof existsSync),
+  } as typeof import('fs')
+}
+
+if (import.meta.vitest) {
+  const { test, expect } = import.meta.vitest
+
+  test('parseIntoFsdRoot', () => {
+    const root = parseIntoFsdRoot(`
+      📂 entities
+        📂 users
+          📂 ui
+          📄 index.ts
+        📂 posts
+          📂 ui
+          📄 index.ts
+      📂 shared
+        📂 ui
+          📄 index.ts
+          📄 Button.tsx
+    `)
+
+    expect(root).toEqual({
+      type: 'folder',
+      path: joinFromRoot(),
+      children: [
+        {
+          type: 'folder',
+          path: joinFromRoot('entities'),
+          children: [
+            {
+              type: 'folder',
+              path: joinFromRoot('entities', 'users'),
+              children: [
+                {
+                  type: 'folder',
+                  path: joinFromRoot('entities', 'users', 'ui'),
+                  children: [],
+                },
+                {
+                  type: 'file',
+                  path: joinFromRoot('entities', 'users', 'index.ts'),
+                },
+              ],
+            },
+            {
+              type: 'folder',
+              path: joinFromRoot('entities', 'posts'),
+              children: [
+                {
+                  type: 'folder',
+                  path: joinFromRoot('entities', 'posts', 'ui'),
+                  children: [],
+                },
+                {
+                  type: 'file',
+                  path: joinFromRoot('entities', 'posts', 'index.ts'),
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'folder',
+          path: joinFromRoot('shared'),
+          children: [
+            {
+              type: 'folder',
+              path: joinFromRoot('shared', 'ui'),
+              children: [
+                {
+                  type: 'file',
+                  path: joinFromRoot('shared', 'ui', 'index.ts'),
+                },
+                {
+                  type: 'file',
+                  path: joinFromRoot('shared', 'ui', 'Button.tsx'),
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  test('it should return a nested root folder when the optional rootPath argument is passed', () => {
+    const markup = `
+      📂 entities
+        📂 users
+          📂 ui
+          📄 index.ts
+        📂 posts
+          📂 ui
+          📄 index.ts
+      📂 shared
+        📂 ui
+          📄 index.ts
+          📄 Button.tsx
+    `
+    const root = parseIntoFsdRoot(markup, joinFromRoot('src'))
+
+    expect(root).toEqual({
+      type: 'folder',
+      path: joinFromRoot('src'),
+      children: [
+        {
+          type: 'folder',
+          path: joinFromRoot('src', 'entities'),
+          children: [
+            {
+              type: 'folder',
+              path: joinFromRoot('src', 'entities', 'users'),
+              children: [
+                {
+                  type: 'folder',
+                  path: joinFromRoot('src', 'entities', 'users', 'ui'),
+                  children: [],
+                },
+                {
+                  type: 'file',
+                  path: joinFromRoot('src', 'entities', 'users', 'index.ts'),
+                },
+              ],
+            },
+            {
+              type: 'folder',
+              path: joinFromRoot('src', 'entities', 'posts'),
+              children: [
+                {
+                  type: 'folder',
+                  path: joinFromRoot('src', 'entities', 'posts', 'ui'),
+                  children: [],
+                },
+                {
+                  type: 'file',
+                  path: joinFromRoot('src', 'entities', 'posts', 'index.ts'),
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'folder',
+          path: joinFromRoot('src', 'shared'),
+          children: [
+            {
+              type: 'folder',
+              path: joinFromRoot('src', 'shared', 'ui'),
+              children: [
+                {
+                  type: 'file',
+                  path: joinFromRoot('src', 'shared', 'ui', 'index.ts'),
+                },
+                {
+                  type: 'file',
+                  path: joinFromRoot('src', 'shared', 'ui', 'Button.tsx'),
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+}

--- a/packages/steiger/src/features/apply-globs.test.ts
+++ b/packages/steiger/src/features/apply-globs.test.ts
@@ -1,0 +1,328 @@
+import { expect, it, describe } from 'vitest'
+
+import applyGlobs from './apply-globs'
+import { joinFromRoot, parseIntoFsdRoot } from '../../../steiger-plugin-fsd/src/_lib/prepare-test'
+
+describe('applyGlobs', () => {
+  it('should return the passed folder if no globs are provided', () => {
+    const root = parseIntoFsdRoot(
+      `
+      📂 shared
+        📂 ui
+          📄 styles.css
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+    `,
+      joinFromRoot('src'),
+    )
+
+    expect(applyGlobs(root, {})).toEqual(root)
+    expect(
+      applyGlobs(root, {
+        inclusions: [],
+        exclusions: [],
+      }),
+    ).toEqual(root)
+  })
+
+  it('should return the picked folder if a specific folder is passed to inclusion patterns', () => {
+    const root = parseIntoFsdRoot(
+      `
+      📂 shared
+        📂 ui
+          📄 styles.css
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 user
+          📄 UserAvatar.tsx
+        📂 product
+          📄 ProductCard.tsx
+    `,
+      joinFromRoot('src'),
+    )
+
+    const expected = parseIntoFsdRoot(
+      `
+      📂 shared
+        📂 ui
+          📄 styles.css
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+    `,
+      joinFromRoot('src'),
+    )
+
+    const actual = applyGlobs(root, {
+      inclusions: ['/src/shared/**'],
+      exclusions: [],
+    })
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should return all __mock__ folders if the inclusion pattern says to include them all', () => {
+    const root = parseIntoFsdRoot(
+      `
+      📂 shared
+        📂 ui
+          📂 __mocks__
+            📄 Button.tsx
+          📄 styles.css
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 user
+          📂 __mocks__
+            📄 UserAvatar.tsx
+          📄 UserAvatar.tsx
+        📂 product
+          📄 ProductCard.tsx
+    `,
+      joinFromRoot('src'),
+    )
+
+    const expected = parseIntoFsdRoot(
+      `
+       📂 shared
+         📂 ui
+           📂 __mocks__
+             📄 Button.tsx
+       📂 entities
+         📂 user
+           📂 __mocks__
+             📄 UserAvatar.tsx
+    `,
+      joinFromRoot('src'),
+    )
+
+    const actual = applyGlobs(root, {
+      inclusions: ['**/__mocks__/**'],
+      exclusions: [],
+    })
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should return files picked by extension if the inclusion patterns pick by extension', () => {
+    const root = parseIntoFsdRoot(
+      `
+      📂 shared
+        📂 ui
+          📄 styles.css
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 user
+          📄 styles.css
+          📄 UserAvatar.tsx
+        📂 product
+          📄 ProductCard.tsx
+    `,
+      joinFromRoot('src'),
+    )
+
+    const expected = parseIntoFsdRoot(
+      `
+       📂 shared
+         📂 ui
+           📄 styles.css
+       📂 entities
+         📂 user
+           📄 styles.css
+    `,
+      joinFromRoot('src'),
+    )
+
+    const actual = applyGlobs(root, {
+      inclusions: ['**/*.css'],
+      exclusions: [],
+    })
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should return a specific single file if the inclusion pattern pick that only file', () => {
+    const root = parseIntoFsdRoot(
+      `
+      📂 shared
+        📂 ui
+          📄 styles.css
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 user
+          📄 styles.css
+          📄 UserAvatar.tsx
+        📂 product
+          📄 ProductCard.tsx
+    `,
+      joinFromRoot('src'),
+    )
+
+    const expected = parseIntoFsdRoot(
+      `
+      📂 shared
+        📂 ui
+          📄 TextField.tsx
+    `,
+      joinFromRoot('src'),
+    )
+
+    const actual = applyGlobs(root, {
+      inclusions: ['/src/shared/ui/TextField.tsx'],
+      exclusions: [],
+    })
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should correctly handle negations in exclusion patterns', () => {
+    const root = parseIntoFsdRoot(
+      `
+      📂 shared
+        📂 ui
+          📄 styles.css
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+        📂 config
+          📄 eslint.config.js
+          📄 styling.config.js
+      📂 entities
+        📂 user
+          📄 styles.css
+          📄 UserAvatar.tsx
+        📂 product
+          📄 ProductCard.tsx
+    `,
+      joinFromRoot('src'),
+    )
+
+    const expected = parseIntoFsdRoot(
+      `
+      📂 shared
+        📂 ui
+          📄 styles.css
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+        📂 config
+          📄 eslint.config.js
+      📂 entities
+        📂 user
+          📄 styles.css
+          📄 UserAvatar.tsx
+        📂 product
+          📄 ProductCard.tsx
+    `,
+      joinFromRoot('src'),
+    )
+
+    const actual = applyGlobs(root, {
+      exclusions: ['**/*.config.js', '!**/eslint.config.js'],
+    })
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should return the fs tree without all __mock__ folders if the exclusion pattern says to ignore them all', () => {
+    const root = parseIntoFsdRoot(
+      `
+      📂 shared
+        📂 ui
+          📂 __mocks__
+            📄 Button.tsx
+          📄 styles.css
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 user
+          📂 __mocks__
+            📄 UserAvatar.tsx
+          📄 UserAvatar.tsx
+        📂 product
+          📄 ProductCard.tsx
+    `,
+      joinFromRoot('src'),
+    )
+
+    const expected = parseIntoFsdRoot(
+      `
+       📂 shared
+         📂 ui
+           📄 styles.css
+           📄 Button.tsx
+           📄 TextField.tsx
+           📄 index.ts
+       📂 entities
+         📂 user
+           📄 UserAvatar.tsx
+         📂 product
+           📄 ProductCard.tsx
+    `,
+      joinFromRoot('src'),
+    )
+
+    const actual = applyGlobs(root, {
+      inclusions: [],
+      exclusions: ['**/__mocks__/**'],
+    })
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should exclude files with specific extension if exclusion pattern is set up accordingly', () => {
+    const root = parseIntoFsdRoot(
+      `
+      📂 shared
+        📂 lib
+          📄 get-query-params.ts
+          📄 get-query-params.test.ts
+        📂 ui
+          📄 styles.css
+          📄 Button.tsx
+          📄 Button.test.tsx
+          📄 TextField.tsx
+          📄 TextField.test.tsx
+          📄 index.ts
+      📂 entities
+        📂 user
+          📄 styles.css
+          📄 UserAvatar.tsx
+          📄 UserAvatar.test.tsx
+        📂 product
+          📄 ProductCard.tsx
+    `,
+      joinFromRoot('src'),
+    )
+
+    const expected = parseIntoFsdRoot(
+      `
+      📂 shared
+        📂 lib
+          📄 get-query-params.ts
+        📂 ui
+          📄 styles.css
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+    `,
+      joinFromRoot('src'),
+    )
+
+    const actual = applyGlobs(root, {
+      inclusions: ['/src/shared/**'],
+      exclusions: ['**/*.test.{tsx,ts}'],
+    })
+
+    expect(actual).toEqual(expected)
+  })
+})

--- a/packages/steiger/src/features/apply-globs.test.ts
+++ b/packages/steiger/src/features/apply-globs.test.ts
@@ -1,7 +1,7 @@
 import { expect, it, describe } from 'vitest'
 
 import applyGlobs from './apply-globs'
-import { joinFromRoot, parseIntoFsdRoot } from '../../../steiger-plugin-fsd/src/_lib/prepare-test'
+import { joinFromRoot, parseIntoFsdRoot } from '../_lib/prepare-test'
 
 describe('applyGlobs', () => {
   it('should return the passed folder if no globs are provided', () => {

--- a/packages/steiger/src/features/apply-globs.ts
+++ b/packages/steiger/src/features/apply-globs.ts
@@ -1,8 +1,10 @@
+import { sep } from 'node:path'
+
 import { minimatch } from 'minimatch'
 import { File, Folder } from '@steiger/types'
+
 import { isNegationPattern } from '../shared/globs'
 import { flattenFolder, copyFsEntity } from '../shared/file-system'
-import { sep } from 'node:path'
 
 interface ApplyGlobsOptions {
   inclusions?: string[]
@@ -23,8 +25,9 @@ function recomposeTree(folder: Folder, nodes: Array<Folder | File>) {
     for (let i = 0; i < pathParts.length; i++) {
       const pathPart = pathParts[i]
       const isLastPart = i === pathParts.length - 1
+      const nextPath = `${currentFolder.path}${sep}${pathPart}`
       const existingFolder = currentFolder.children.find(
-        (child) => child.type === 'folder' && child.path === `${currentFolder.path}${sep}${pathPart}`,
+        (child) => child.type === 'folder' && child.path === nextPath,
       ) as Folder | undefined
 
       if (isLastPart && nested.type === 'file') {
@@ -37,7 +40,7 @@ function recomposeTree(folder: Folder, nodes: Array<Folder | File>) {
       } else {
         const newFolder: Folder = {
           type: 'folder',
-          path: `${currentFolder.path}${sep}${pathPart}`,
+          path: nextPath,
           children: [],
         }
         currentFolder.children.push(newFolder)

--- a/packages/steiger/src/features/apply-globs.ts
+++ b/packages/steiger/src/features/apply-globs.ts
@@ -27,6 +27,9 @@ function copyFsEntity<T extends Folder | File>(fsEntity: T, deep: boolean = fals
   return { ...fsEntity }
 }
 
+/**
+ * Turn a tree folder structure into a flat array of folders/files.
+ * */
 function flattenFolder(folder: Folder): File[] {
   return folder.children.reduce((acc, child) => {
     if (child.type === 'file') {
@@ -37,6 +40,9 @@ function flattenFolder(folder: Folder): File[] {
   }, [] as File[])
 }
 
+/**
+ * Turns flat array of files and folders into a tree structure based on the paths.
+ * */
 function recomposeTree(folder: Folder, nodes: Array<Folder | File>) {
   function createPath(folder: Folder, nested: Folder | File) {
     const pathDiff = nested.path.slice(folder.path.length + 1)
@@ -104,7 +110,7 @@ function createFilterAccordingToGlobs({ inclusions, exclusions }: RequiredApplyG
   return filterAccordingToGlobs
 }
 
-// ! Don't use platform specific path separators in the glob patterns for globby
+// ! Don't use platform specific path separators in the glob patterns for globby/minimatch
 // as it only works with forward slashes!
 
 /**

--- a/packages/steiger/src/features/apply-globs.ts
+++ b/packages/steiger/src/features/apply-globs.ts
@@ -1,0 +1,128 @@
+import { minimatch } from 'minimatch'
+import { File, Folder } from '@steiger/types'
+
+interface ApplyGlobsOptions {
+  inclusions?: string[]
+  exclusions?: string[]
+}
+
+type RequiredApplyGlobsOptions = Required<ApplyGlobsOptions>
+
+function isNegationPattern(pattern: string) {
+  return pattern.startsWith('!')
+}
+
+function copyFsEntity<T extends Folder | File>(fsEntity: T, deep: boolean = false) {
+  if (fsEntity.type === 'folder') {
+    const newChildren: Array<Folder | File> = deep
+      ? fsEntity.children.map((child) => (child.type === 'folder' ? copyFsEntity(child, true) : child))
+      : []
+
+    return {
+      ...fsEntity,
+      children: newChildren,
+    }
+  }
+
+  return { ...fsEntity }
+}
+
+function flattenFolder(folder: Folder): File[] {
+  return folder.children.reduce((acc, child) => {
+    if (child.type === 'file') {
+      return [...acc, child]
+    }
+
+    return [...acc, ...flattenFolder(child)]
+  }, [] as File[])
+}
+
+function recomposeTree(folder: Folder, nodes: Array<Folder | File>) {
+  function createPath(folder: Folder, nested: Folder | File) {
+    const pathDiff = nested.path.slice(folder.path.length + 1)
+    const pathParts = pathDiff.split('/').filter(Boolean)
+    let currentFolder = folder
+
+    for (let i = 0; i < pathParts.length; i++) {
+      const pathPart = pathParts[i]
+      const isLastPart = i === pathParts.length - 1
+      const existingFolder = currentFolder.children.find(
+        (child) => child.type === 'folder' && child.path === `${currentFolder.path}/${pathPart}`,
+      )
+
+      if (isLastPart && nested.type === 'file') {
+        currentFolder.children.push(nested)
+        return
+      }
+
+      if (existingFolder) {
+        currentFolder = existingFolder as Folder
+      } else {
+        const newFolder: Folder = {
+          type: 'folder',
+          path: `${currentFolder.path}/${pathPart}`,
+          children: [],
+        }
+        currentFolder.children.push(newFolder)
+        currentFolder = newFolder
+      }
+    }
+  }
+
+  nodes.forEach((node) => {
+    createPath(folder, node)
+  })
+}
+
+function createFilterAccordingToGlobs({ inclusions, exclusions }: RequiredApplyGlobsOptions) {
+  const thereAreInclusions = inclusions.length > 0
+  const thereAreExclusions = exclusions.length > 0
+
+  function filterAccordingToGlobs(entity: File | Folder) {
+    const matchesInclusionPatterns =
+      !thereAreInclusions || inclusions.some((pattern) => minimatch(entity.path, pattern))
+    let isIgnored = false
+
+    if (matchesInclusionPatterns && thereAreExclusions) {
+      isIgnored = exclusions
+        .filter((pattern) => !isNegationPattern(pattern))
+        .some((pattern) => minimatch(entity.path, pattern))
+
+      // If the path is ignored, check for any negated patterns that would include it back
+      if (isIgnored) {
+        const isNegated = exclusions.some(
+          (ignorePattern) => isNegationPattern(ignorePattern) && minimatch(entity.path, ignorePattern.slice(1)),
+        )
+
+        isIgnored = !isNegated
+      }
+    }
+
+    return matchesInclusionPatterns && !isIgnored
+  }
+
+  return filterAccordingToGlobs
+}
+
+// ! Don't use platform specific path separators in the glob patterns for globby
+// as it only works with forward slashes!
+
+/**
+ * Apply glob patterns to a folder and return a new folder with only the matched files and folders.
+ * */
+export default function applyGlobs(folder: Folder, { inclusions = [], exclusions = [] }: ApplyGlobsOptions) {
+  // if there's nothing to match then return the folder as is
+  if (!inclusions?.length && !exclusions?.length) {
+    return folder
+  }
+
+  const accordingToGlobs = createFilterAccordingToGlobs({ inclusions, exclusions })
+  const flatFilteredFsNodes = flattenFolder(folder)
+    .map((entity) => copyFsEntity(entity))
+    .filter(accordingToGlobs)
+  const finalFolder = copyFsEntity(folder)
+
+  recomposeTree(finalFolder, flatFilteredFsNodes)
+
+  return finalFolder
+}

--- a/packages/steiger/src/shared/file-system.ts
+++ b/packages/steiger/src/shared/file-system.ts
@@ -1,0 +1,29 @@
+import { File, Folder } from '@steiger/types'
+
+/**
+ * Turn a tree folder structure into a flat array of files.
+ * */
+export function flattenFolder(folder: Folder): File[] {
+  return folder.children.reduce((acc, child) => {
+    if (child.type === 'file') {
+      return [...acc, child]
+    }
+
+    return [...acc, ...flattenFolder(child)]
+  }, [] as File[])
+}
+
+export function copyFsEntity<T extends Folder | File>(fsEntity: T, deep: boolean = false) {
+  if (fsEntity.type === 'folder') {
+    const newChildren: Array<Folder | File> = deep
+      ? fsEntity.children.map((child) => (child.type === 'folder' ? copyFsEntity(child, true) : child))
+      : []
+
+    return {
+      ...fsEntity,
+      children: newChildren,
+    }
+  }
+
+  return { ...fsEntity }
+}

--- a/packages/steiger/src/shared/globs.ts
+++ b/packages/steiger/src/shared/globs.ts
@@ -1,0 +1,3 @@
+export function isNegationPattern(pattern: string) {
+  return pattern.startsWith('!')
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       immer:
         specifier: ^10.1.1
         version: 10.1.1
+      minimatch:
+        specifier: ^10.0.1
+        version: 10.0.1
       patronum:
         specifier: ^2.2.0
         version: 2.2.0(effector@23.2.2)
@@ -2186,6 +2189,10 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimatch@10.0.1:
+    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+    engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -5210,6 +5217,10 @@ snapshots:
   mimic-response@4.0.0: {}
 
   min-indent@1.0.1: {}
+
+  minimatch@10.0.1:
+    dependencies:
+      brace-expansion: 2.0.1
 
   minimatch@3.1.2:
     dependencies:


### PR DESCRIPTION
Resolves #66 

Hi   @illright 

Sorry for the delay. I wanted to complete this task earlier, but a terrible force majeure happened at the beginning of the week.

… but finally here’s my solution.  
Just a few annotations for it: 
- I saw that we already had a glob matching library “globby” in place but I then had to install "minimatch" because globby cannot just match file path to a pattern, it needs to traverse the real FS.
- I just implemented the functionality and didn’t connect it to other parts as we discussed it would be done in further tasks
- I had a question about test utils (and Ileft it on the specific line) 