### PR TITLE
Add a codemod for transforming configs to the new format

### DIFF
--- a/packages/steiger/migrations/transform-config.js
+++ b/packages/steiger/migrations/transform-config.js
@@ -1,0 +1,46 @@
+/** @type {import('jscodeshift').Transform} */
+export default function transformer(file, api) {
+  const j = api.jscodeshift
+  const root = j(file.source)
+
+  // Add "fsd/" prefix to FSD rule names
+  root
+    .find(j.Literal)
+    .filter((path) => ruleNames.includes(path.node.value))
+    .replaceWith((path) => j.stringLiteral(`fsd/${path.node.value}`))
+
+  // Make the default export or the argument of `defineConfig` an array
+  const defineConfigCalls = root.find(j.CallExpression).filter((path) => path.node.callee.name === 'defineConfig')
+
+  if (defineConfigCalls.length > 0) {
+    defineConfigCalls
+      .find(j.ObjectExpression)
+      .at(0)
+      .replaceWith((path) => j.arrayExpression([path.value]))
+  } else {
+    root.find(j.ExportDefaultDeclaration).forEach((path) => {
+      path.value.declaration = j.arrayExpression([path.value.declaration])
+    })
+  }
+
+  return root.toSource()
+}
+
+const ruleNames = [
+  'ambiguous-slice-names',
+  'excessive-slicing',
+  'forbidden-imports',
+  'inconsistent-naming',
+  'insignificant-slice',
+  'no-layer-public-api',
+  'no-public-api-sidestep',
+  'no-reserved-folder-names',
+  'no-segmentless-slices',
+  'no-segments-on-sliced-layers',
+  'public-api',
+  'repetitive-naming',
+  'segments-by-purpose',
+  'shared-lib-grouping',
+  'no-processes',
+  'import-locality',
+]


### PR DESCRIPTION
Create a `steiger.config.js` in the current directory and test the codemod with the following command:
```bash
pnpx jscodeshift -t https://raw.githubusercontent.com/feature-sliced/steiger/codemod/packages/steiger/migrations/transform-config.js steiger.config.js
```

This command is huge, but the migration is so simple that I don't think our users will mind. I suggest writing this in the migration guide, although we will replace the branch name once this is merged.

Alternatively, you can test it [here in the browser](https://stackblitz.com/edit/stackblitz-starters-gnpapk?file=steiger.config.1.js&view=editor) by running this in the terminal of StackBlitz:
```bash
npx jscodeshift --dry -p steiger.config.1.js
```
