### PR TITLE
Add typo-in-layer-name rule

### DIFF
--- a/.changeset/unlucky-coins-accept.md
+++ b/.changeset/unlucky-coins-accept.md
@@ -1,0 +1,6 @@
+---
+'@feature-sliced/steiger-plugin': minor
+'steiger': minor
+---
+
+Add typo-in-layer-name rule

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Currently, Steiger is not extendable with more rules, though that will change in
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/repetitive-naming/README.md"><code>repetitive-naming</code></a></td> <td>Ensure that all entities are named consistently in terms of pluralization.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/segments-by-purpose/README.md"><code>segments-by-purpose</code></a></td> <td>Discourage the use of segment names that group code by its essence, and instead encourage grouping by purpose</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/shared-lib-grouping/README.md"><code>shared-lib-grouping</code></a></td> <td>Forbid having too many ungrouped modules in <code>shared/lib</code>.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/typo-in-layer-name/README.md"><code>typo-in-layer-name</code></a></td> <td>Ensure that all layers are named without any typos.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-processes/README.md"><code>no-processes</code></a></td> <td>Discourage the use of the deprecated Processes layer.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/import-locality/README.md"><code>import-locality</code></a></td> <td>Require that imports from the same slice be relative and imports from one slice to another be absolute.</td> </tr>
 </tbody>

--- a/packages/steiger-plugin-fsd/package.json
+++ b/packages/steiger-plugin-fsd/package.json
@@ -31,6 +31,7 @@
   ],
   "dependencies": {
     "@feature-sliced/filesystem": "^2.2.5",
+    "fastest-levenshtein": "^1.0.16",
     "lodash-es": "^4.17.21",
     "pluralize": "^8.0.0",
     "precinct": "^12.1.1",

--- a/packages/steiger-plugin-fsd/src/index.ts
+++ b/packages/steiger-plugin-fsd/src/index.ts
@@ -15,6 +15,7 @@ import publicApi from './public-api/index.js'
 import repetitiveNaming from './repetitive-naming/index.js'
 import segmentsByPurpose from './segments-by-purpose/index.js'
 import sharedLibGrouping from './shared-lib-grouping/index.js'
+import typoInLayerName from './typo-in-layer-name/index.js'
 import noProcesses from './no-processes/index.js'
 import packageJson from '../package.json'
 
@@ -34,6 +35,7 @@ const allRules: Array<Rule> = [
   repetitiveNaming,
   segmentsByPurpose,
   sharedLibGrouping,
+  typoInLayerName,
   noProcesses,
 ]
 

--- a/packages/steiger-plugin-fsd/src/typo-in-layer-name/README.md
+++ b/packages/steiger-plugin-fsd/src/typo-in-layer-name/README.md
@@ -26,4 +26,4 @@ Examples of project structures that fail this rule:
 
 ## Rationale
 
-The methodology contains a standardized set of layers. By enforcing uniform naming conventions, this rule checks for any potential typos, improving the quality of projects.
+The methodology contains a standardized set of layers. Enforcing these naming conventions is important for other developers, as well as for other rules of the linter to work correctly.

--- a/packages/steiger-plugin-fsd/src/typo-in-layer-name/README.md
+++ b/packages/steiger-plugin-fsd/src/typo-in-layer-name/README.md
@@ -1,0 +1,29 @@
+# `typo-in-layer-name`
+
+Ensure that all layers are named consistently without any typos.
+
+Examples of project structures that pass this rule:
+
+```
+📂 shared
+📂 entities
+📂 features
+📂 widgets
+📂 pages
+📂 app
+```
+
+Examples of project structures that fail this rule:
+
+```
+📂 shraed  // ❌
+📂 entities
+📂 fietures  // ❌
+📂 wigdets  // ❌
+📂 page  // ❌
+📂 app
+```
+
+## Rationale
+
+The methodology contains a standardized set of layers. By enforcing uniform naming conventions, this rule checks for any potential typos, improving the quality of projects.

--- a/packages/steiger-plugin-fsd/src/typo-in-layer-name/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/typo-in-layer-name/index.spec.ts
@@ -29,6 +29,10 @@ it('reports errors on a project with typos in layer names', () => {
   const diagnostics = typoInLayerName.check(root).diagnostics
   expect(diagnostics).toEqual([
     {
+      message: 'Layer "page" potentially contains a typo. Did you mean "pages"?',
+      location: { path: joinFromRoot('page') },
+    },
+    {
       message: 'Layer "shraed" potentially contains a typo. Did you mean "shared"?',
       location: { path: joinFromRoot('shraed') },
     },
@@ -40,9 +44,57 @@ it('reports errors on a project with typos in layer names', () => {
       message: 'Layer "wigdets" potentially contains a typo. Did you mean "widgets"?',
       location: { path: joinFromRoot('wigdets') },
     },
+  ])
+})
+
+it('reports no errors on a project with custom layers if base layers are present', () => {
+  const root = parseIntoFsdRoot(`
+    📂 shared
+    📂 shapes
+    📂 entities
+    📂 entries
+    📂 features
+    📂 fixtures
+    📂 widgets
+    📂 pages
+    📂 places
+    📂 app
+    📂 amp
+  `)
+
+  expect(typoInLayerName.check(root)).toEqual({ diagnostics: [] })
+})
+
+it('reports errors on a project with custom layers if base layers are absent', () => {
+  const root = parseIntoFsdRoot(`
+    📂 shapes
+    📂 entries
+    📂 fixtures
+    📂 places
+    📂 amp
+  `)
+
+  const diagnostics = typoInLayerName.check(root).diagnostics
+  expect(diagnostics).toEqual([
     {
-      message: 'Layer "page" potentially contains a typo. Did you mean "pages"?',
-      location: { path: joinFromRoot('page') },
+      message: 'Layer "amp" potentially contains a typo. Did you mean "app"?',
+      location: { path: joinFromRoot('amp') },
+    },
+    {
+      message: 'Layer "shapes" potentially contains a typo. Did you mean "shared"?',
+      location: { path: joinFromRoot('shapes') },
+    },
+    {
+      message: 'Layer "entries" potentially contains a typo. Did you mean "entities"?',
+      location: { path: joinFromRoot('entries') },
+    },
+    {
+      message: 'Layer "fixtures" potentially contains a typo. Did you mean "features"?',
+      location: { path: joinFromRoot('fixtures') },
+    },
+    {
+      message: 'Layer "places" potentially contains a typo. Did you mean "pages"?',
+      location: { path: joinFromRoot('places') },
     },
   ])
 })

--- a/packages/steiger-plugin-fsd/src/typo-in-layer-name/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/typo-in-layer-name/index.spec.ts
@@ -1,0 +1,48 @@
+import { expect, it } from 'vitest'
+
+import typoInLayerName from './index.js'
+import { joinFromRoot, parseIntoFsdRoot } from '../_lib/prepare-test.js'
+
+it('reports no errors on a project without typos in layer names', () => {
+  const root = parseIntoFsdRoot(`
+    📂 shared
+    📂 entities
+    📂 features
+    📂 widgets
+    📂 pages
+    📂 app
+  `)
+
+  expect(typoInLayerName.check(root)).toEqual({ diagnostics: [] })
+})
+
+it('reports errors on a project with typos in layer names', () => {
+  const root = parseIntoFsdRoot(`
+    📂 shraed
+    📂 entities
+    📂 fietures
+    📂 wigdets
+    📂 page
+    📂 app
+  `)
+
+  const diagnostics = typoInLayerName.check(root).diagnostics
+  expect(diagnostics).toEqual([
+    {
+      message: 'Layer "shraed" potentially contains a typo. Did you mean "shared"?',
+      location: { path: joinFromRoot('shraed') },
+    },
+    {
+      message: 'Layer "fietures" potentially contains a typo. Did you mean "features"?',
+      location: { path: joinFromRoot('fietures') },
+    },
+    {
+      message: 'Layer "wigdets" potentially contains a typo. Did you mean "widgets"?',
+      location: { path: joinFromRoot('wigdets') },
+    },
+    {
+      message: 'Layer "page" potentially contains a typo. Did you mean "pages"?',
+      location: { path: joinFromRoot('page') },
+    },
+  ])
+})

--- a/packages/steiger-plugin-fsd/src/typo-in-layer-name/index.ts
+++ b/packages/steiger-plugin-fsd/src/typo-in-layer-name/index.ts
@@ -1,26 +1,64 @@
 import type { Diagnostic, Rule } from '@steiger/types'
 import { NAMESPACE } from '../constants.js'
-import { layerSequence } from '@feature-sliced/filesystem'
-import { closest } from 'fastest-levenshtein'
+import { LayerName, layerSequence } from '@feature-sliced/filesystem'
+import { distance } from 'fastest-levenshtein'
 import { basename } from 'node:path'
+import { joinFromRoot } from '../_lib/prepare-test.js'
+
+const LEVENSHTEIN_DISTANCE_UPPER_BOUND = 3
 
 const typoInLayerName = {
   name: `${NAMESPACE}/typo-in-layer-name`,
   check(root) {
     const diagnostics: Array<Diagnostic> = []
 
-    root.children.forEach((child) => {
-      if (child.type === 'folder') {
+    // construct list of suggestions, like [{ input: 'shraed', suggestion: 'shared', distance: 2 }, ...],
+    // limit Levenshtein distance upper bound to 3,
+    // sort by Levenshtein distance in ascending order,
+    const suggestionsList = root.children
+      .filter((child) => child.type === 'folder')
+      .flatMap((child) => {
         const layer = basename(child.path)
-        const closestLayer = closest(layer, layerSequence)
 
-        if (layer !== closestLayer) {
-          diagnostics.push({
-            message: `Layer "${layer}" potentially contains a typo. Did you mean "${closestLayer}"?`,
-            location: { path: child.path },
-          })
-        }
+        return layerSequence
+          .map((sequenceLayer) => ({
+            input: layer,
+            suggestion: sequenceLayer,
+            distance: distance(layer, sequenceLayer),
+          }))
+          .filter((layer) => layer.distance <= LEVENSHTEIN_DISTANCE_UPPER_BOUND)
+      })
+      .sort((a, b) => a.distance - b.distance)
+
+    const processedInputs: string[] = []
+    const suggestedLayers: LayerName[] = []
+
+    suggestionsList.forEach((layer) => {
+      // if Levenshtein distance is 0, the layer name is correct - add it as a "suggestion"
+      if (layer.distance === 0) {
+        suggestedLayers.push(layer.suggestion)
+
+        return
       }
+
+      // if the input is already processed, the suggestion for this input is already added
+      if (processedInputs.includes(layer.input)) {
+        return
+      }
+
+      // if the suggestion is already added, it cannot be used for this input
+      if (suggestedLayers.includes(layer.suggestion)) {
+        return
+      }
+
+      // mark the input as processed & add suitable suggestion
+      processedInputs.push(layer.input)
+      suggestedLayers.push(layer.suggestion)
+
+      diagnostics.push({
+        message: `Layer "${layer.input}" potentially contains a typo. Did you mean "${layer.suggestion}"?`,
+        location: { path: joinFromRoot(layer.input) },
+      })
     })
 
     return { diagnostics }

--- a/packages/steiger-plugin-fsd/src/typo-in-layer-name/index.ts
+++ b/packages/steiger-plugin-fsd/src/typo-in-layer-name/index.ts
@@ -1,0 +1,30 @@
+import type { Diagnostic, Rule } from '@steiger/types'
+import { NAMESPACE } from '../constants.js'
+import { layerSequence } from '@feature-sliced/filesystem'
+import { closest } from 'fastest-levenshtein'
+import { basename } from 'node:path'
+
+const typoInLayerName = {
+  name: `${NAMESPACE}/typo-in-layer-name`,
+  check(root) {
+    const diagnostics: Array<Diagnostic> = []
+
+    root.children.forEach((child) => {
+      if (child.type === 'folder') {
+        const layer = basename(child.path)
+        const closestLayer = closest(layer, layerSequence)
+
+        if (layer !== closestLayer) {
+          diagnostics.push({
+            message: `Layer "${layer}" potentially contains a typo. Did you mean "${closestLayer}"?`,
+            location: { path: child.path },
+          })
+        }
+      }
+    })
+
+    return { diagnostics }
+  },
+} satisfies Rule
+
+export default typoInLayerName

--- a/packages/steiger/README.md
+++ b/packages/steiger/README.md
@@ -74,6 +74,7 @@ Currently, Steiger is not extendable with more rules, though that will change in
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/repetitive-naming/README.md"><code>repetitive-naming</code></a></td> <td>Ensure that all entities are named consistently in terms of pluralization.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/segments-by-purpose/README.md"><code>segments-by-purpose</code></a></td> <td>Discourage the use of segment names that group code by its essence, and instead encourage grouping by purpose</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/shared-lib-grouping/README.md"><code>shared-lib-grouping</code></a></td> <td>Forbid having too many ungrouped modules in <code>shared/lib</code>.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/typo-in-layer-name/README.md"><code>typo-in-layer-name</code></a></td> <td>Ensure that all layers are named without any typos.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-processes/README.md"><code>no-processes</code></a></td> <td>Discourage the use of the deprecated Processes layer.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/import-locality/README.md"><code>import-locality</code></a></td> <td>Require that imports from the same slice be relative and imports from one slice to another be absolute.</td> </tr>
 </tbody>

--- a/packages/steiger/migrations/convert-config-to-flat.js
+++ b/packages/steiger/migrations/convert-config-to-flat.js
@@ -68,6 +68,7 @@ const ruleNames = [
   'repetitive-naming',
   'segments-by-purpose',
   'shared-lib-grouping',
+  'typo-in-layer-name',
   'no-processes',
   'import-locality',
 ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@feature-sliced/filesystem':
         specifier: ^2.2.5
         version: 2.2.5
+      fastest-levenshtein:
+        specifier: ^1.0.16
+        version: 1.0.16
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1645,6 +1648,10 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
 
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -4697,6 +4704,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fastest-levenshtein@1.0.16: {}
 
   fastq@1.17.1:
     dependencies:


### PR DESCRIPTION
Resolves #93 

I checked a few packages which have built-in spellcheck feature, but they don't fit the needs due to:
- require additional dictionary, e.g. in `.aff` or `.dic` formats ([nodehun](https://github.com/Wulf/nodehun), [nspell](https://github.com/wooorm/nspell), [typojs](https://github.com/cfinke/Typo.js))
- archived repo (maybe not crucial, but still) ([node-spellchecker](https://github.com/atom/node-spellchecker))
- have a huge size ([natural](https://github.com/NaturalNode/natural), ~7MB)

So, I decided to use lightweight & fast package called [fastest-levenshtein](https://github.com/ka-weihe/fastest-levenshtein) which implements [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) algorithm.