### PR TITLE
Fix compilerOptions.paths resolution on Windows

### DIFF
--- a/.changeset/spotty-yaks-listen.md
+++ b/.changeset/spotty-yaks-listen.md
@@ -1,0 +1,5 @@
+---
+'@feature-sliced/steiger-plugin': patch
+---
+
+Fix path resolution on Windows

--- a/packages/steiger-plugin-fsd/src/_lib/collect-related-ts-configs.ts
+++ b/packages/steiger-plugin-fsd/src/_lib/collect-related-ts-configs.ts
@@ -151,7 +151,7 @@ if (import.meta.vitest) {
           },
         },
         {
-          tsconfigFile: joinFromRoot('/.nuxt', '/tsconfig.json'),
+          tsconfigFile: joinFromRoot('.nuxt', 'tsconfig.json'),
           tsconfig: {
             compilerOptions: {
               paths: {

--- a/packages/steiger-plugin-fsd/src/_lib/collect-related-ts-configs.ts
+++ b/packages/steiger-plugin-fsd/src/_lib/collect-related-ts-configs.ts
@@ -145,7 +145,7 @@ if (import.meta.vitest) {
     const payload: CollectRelatedTsConfigsPayload = {
       extended: [
         {
-          tsconfigFile: joinFromRoot('/tsconfig.json'),
+          tsconfigFile: joinFromRoot('tsconfig.json'),
           tsconfig: {
             extends: './.nuxt/tsconfig.json',
           },

--- a/packages/steiger-plugin-fsd/src/_lib/collect-related-ts-configs.ts
+++ b/packages/steiger-plugin-fsd/src/_lib/collect-related-ts-configs.ts
@@ -145,13 +145,13 @@ if (import.meta.vitest) {
     const payload: CollectRelatedTsConfigsPayload = {
       extended: [
         {
-          tsconfigFile: joinFromRoot('tsconfig.json'),
+          tsconfigFile: resolve(joinFromRoot('tsconfig.json')),
           tsconfig: {
             extends: './.nuxt/tsconfig.json',
           },
         },
         {
-          tsconfigFile: joinFromRoot('.nuxt', 'tsconfig.json'),
+          tsconfigFile: resolve(joinFromRoot('.nuxt', 'tsconfig.json')),
           tsconfig: {
             compilerOptions: {
               paths: {
@@ -168,7 +168,7 @@ if (import.meta.vitest) {
           },
         },
       ],
-      tsconfigFile: joinFromRoot('tsconfig.json'),
+      tsconfigFile: resolve(joinFromRoot('tsconfig.json')),
       tsconfig: {
         extends: './.nuxt/tsconfig.json',
         compilerOptions: {
@@ -191,8 +191,8 @@ if (import.meta.vitest) {
         extends: './.nuxt/tsconfig.json',
         compilerOptions: {
           paths: {
-            '~': [joinFromRoot()],
-            '~/*': [joinFromRoot('*')],
+            '~': [resolve(joinFromRoot())],
+            '~/*': [resolve(joinFromRoot('*'))],
           },
           strict: true,
           noUncheckedIndexedAccess: false,
@@ -209,7 +209,7 @@ if (import.meta.vitest) {
 
   test('resolves paths independently from the current directory', () => {
     const payload: CollectRelatedTsConfigsPayload = {
-      tsconfigFile: joinFromRoot('user', 'projects', 'project-0', 'tsconfig.json'),
+      tsconfigFile: resolve(joinFromRoot('user', 'projects', 'project-0', 'tsconfig.json')),
       tsconfig: {
         compilerOptions: {
           paths: {
@@ -230,8 +230,8 @@ if (import.meta.vitest) {
       {
         compilerOptions: {
           paths: {
-            '~': [joinFromRoot('user', 'projects', 'project-0', 'src')],
-            '~/*': [joinFromRoot('user', 'projects', 'project-0', 'src', '*')],
+            '~': [resolve(joinFromRoot('user', 'projects', 'project-0', 'src'))],
+            '~/*': [resolve(joinFromRoot('user', 'projects', 'project-0', 'src', '*'))],
           },
           strict: true,
           noUncheckedIndexedAccess: false,

--- a/packages/steiger-plugin-fsd/src/_lib/collect-related-ts-configs.ts
+++ b/packages/steiger-plugin-fsd/src/_lib/collect-related-ts-configs.ts
@@ -168,7 +168,7 @@ if (import.meta.vitest) {
           },
         },
       ],
-      tsconfigFile: joinFromRoot('/tsconfig.json'),
+      tsconfigFile: joinFromRoot('tsconfig.json'),
       tsconfig: {
         extends: './.nuxt/tsconfig.json',
         compilerOptions: {

--- a/packages/steiger-plugin-fsd/src/_lib/collect-related-ts-configs.ts
+++ b/packages/steiger-plugin-fsd/src/_lib/collect-related-ts-configs.ts
@@ -1,5 +1,6 @@
 import { TSConfckParseResult } from 'tsconfck'
-import { dirname, posix } from 'node:path'
+import { dirname, resolve } from 'node:path'
+import { joinFromRoot } from '@steiger/toolkit'
 
 export type CollectRelatedTsConfigsPayload = {
   tsconfig: TSConfckParseResult['tsconfig']
@@ -115,7 +116,7 @@ function makeRelativePathAliasesAbsolute(
   for (const entries of Object.entries(mergedConfig.compilerOptions.paths)) {
     const [key, paths] = entries as [key: string, paths: Array<string>]
     absolutePaths[key] = paths.map((relativePath: string) =>
-      posix.resolve(dirname(firstConfigWithPaths.tsconfigFile!), relativePath),
+      resolve(dirname(firstConfigWithPaths.tsconfigFile!), relativePath),
     )
   }
 
@@ -144,13 +145,13 @@ if (import.meta.vitest) {
     const payload: CollectRelatedTsConfigsPayload = {
       extended: [
         {
-          tsconfigFile: '/tsconfig.json',
+          tsconfigFile: joinFromRoot('/tsconfig.json'),
           tsconfig: {
             extends: './.nuxt/tsconfig.json',
           },
         },
         {
-          tsconfigFile: '/.nuxt/tsconfig.json',
+          tsconfigFile: joinFromRoot('/.nuxt', '/tsconfig.json'),
           tsconfig: {
             compilerOptions: {
               paths: {
@@ -167,7 +168,7 @@ if (import.meta.vitest) {
           },
         },
       ],
-      tsconfigFile: '/tsconfig.json',
+      tsconfigFile: joinFromRoot('/tsconfig.json'),
       tsconfig: {
         extends: './.nuxt/tsconfig.json',
         compilerOptions: {
@@ -190,8 +191,8 @@ if (import.meta.vitest) {
         extends: './.nuxt/tsconfig.json',
         compilerOptions: {
           paths: {
-            '~': ['/'],
-            '~/*': ['/*'],
+            '~': [joinFromRoot()],
+            '~/*': [joinFromRoot('*')],
           },
           strict: true,
           noUncheckedIndexedAccess: false,
@@ -208,7 +209,7 @@ if (import.meta.vitest) {
 
   test('resolves paths independently from the current directory', () => {
     const payload: CollectRelatedTsConfigsPayload = {
-      tsconfigFile: '/user/projects/project-0/tsconfig.json',
+      tsconfigFile: joinFromRoot('user', 'projects', 'project-0', 'tsconfig.json'),
       tsconfig: {
         compilerOptions: {
           paths: {
@@ -229,8 +230,8 @@ if (import.meta.vitest) {
       {
         compilerOptions: {
           paths: {
-            '~': ['/user/projects/project-0/src'],
-            '~/*': ['/user/projects/project-0/src/*'],
+            '~': [joinFromRoot('user', 'projects', 'project-0', 'src')],
+            '~/*': [joinFromRoot('user', 'projects', 'project-0', 'src', '*')],
           },
           strict: true,
           noUncheckedIndexedAccess: false,


### PR DESCRIPTION
This PR fixes `compilerOptions.paths` resolution on Windows. The problem is that after the release, if paths are defined in tsconfig, they are not resolved correctly, and therefore Steiger does not see relations between some files.