### PR TITLE
Limit what's published to npm in `@feature-sliced/steiger-plugin`

### DIFF
--- a/packages/steiger-plugin-fsd/package.json
+++ b/packages/steiger-plugin-fsd/package.json
@@ -17,8 +17,7 @@
   },
   "files": [
     "dist",
-    "src",
-    "README.md"
+    "src"
   ],
   "type": "module",
   "license": "MIT",

--- a/packages/steiger-plugin-fsd/package.json
+++ b/packages/steiger-plugin-fsd/package.json
@@ -15,6 +15,11 @@
     "types": "./dist/index.d.ts",
     "import": "./dist/index.js"
   },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "type": "module",
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
I noticed we have a lot of useless files in npm, especially `.turbo` — https://www.npmjs.com/package/@feature-sliced/steiger-plugin?activeTab=code

This PR will make sure we're only publishing `src` and `dist`