### PR TITLE
Added support of the steiger config for windows

### DIFF
--- a/.changeset/early-stingrays-appear.md
+++ b/.changeset/early-stingrays-appear.md
@@ -1,0 +1,5 @@
+---
+'steiger': minor
+---
+
+Added support of the steiger config for windows

--- a/.changeset/early-stingrays-appear.md
+++ b/.changeset/early-stingrays-appear.md
@@ -1,5 +1,5 @@
 ---
-'steiger': minor
+'steiger': patch
 ---
 
-Added support of the steiger config for windows
+Fix drive label handling in paths on Windows

--- a/packages/steiger/src/models/config/transform-globs.spec.ts
+++ b/packages/steiger/src/models/config/transform-globs.spec.ts
@@ -1,58 +1,11 @@
-import { describe, expect, it, vi } from 'vitest'
-import { PlatformPath } from 'node:path'
-import { resolve as resolveWindows } from 'node:path/win32'
-import { resolve as resolveUnix } from 'node:path/posix'
+import { describe, expect, it } from 'vitest'
 import { Config, Rule } from '@steiger/types'
 import { transformGlobs } from './transform-globs'
 
-let globalPlatform = ''
-
-vi.mock('path', async (importOriginal) => {
-  const actual: PlatformPath = await importOriginal()
-  return {
-    ...actual,
-    resolve: vi.fn((...args) => {
-      return globalPlatform === 'windows' ? resolveWindows(...args) : resolveUnix(...args)
-    }),
-  }
-})
+const platform = process.platform
 
 describe('transformGlobs', () => {
-  it.each([
-    {
-      platform: 'unix',
-      configLocationPath: '/projects/dummy-project',
-      expectedGlobs: [
-        {
-          ignores: ['/projects/dummy-project/src/entities/**'],
-        },
-        {
-          rules: {
-            rule1: 'warn',
-          },
-          files: ['/projects/dummy-project/src/shared/ui/**/*'],
-          ignores: ['/projects/dummy-project/src/shared/ui/index.ts'],
-        },
-      ],
-    },
-    {
-      platform: 'windows',
-      configLocationPath: 'C:/projects/dummy-project',
-      expectedGlobs: [
-        {
-          ignores: ['C:/projects/dummy-project/src/entities/**'],
-        },
-        {
-          rules: {
-            rule1: 'warn',
-          },
-          files: ['C:/projects/dummy-project/src/shared/ui/**/*'],
-          ignores: ['C:/projects/dummy-project/src/shared/ui/index.ts'],
-        },
-      ],
-    },
-  ])(`should convert relative globs to absolute on $platform`, ({ platform, configLocationPath, expectedGlobs }) => {
-    globalPlatform = platform
+  it.runIf(platform === 'linux')(`should convert relative globs to absolute`, () => {
     const config: Config<Array<Rule>> = [
       {
         ignores: ['./src/entities/**'],
@@ -66,44 +19,49 @@ describe('transformGlobs', () => {
       },
     ]
 
-    expect(transformGlobs(config, configLocationPath)).toEqual(expectedGlobs)
+    expect(transformGlobs(config, '/projects/dummy-project')).toEqual([
+      {
+        ignores: ['/projects/dummy-project/src/entities/**'],
+      },
+      {
+        rules: {
+          rule1: 'warn',
+        },
+        files: ['/projects/dummy-project/src/shared/ui/**/*'],
+        ignores: ['/projects/dummy-project/src/shared/ui/index.ts'],
+      },
+    ])
   })
 
-  it.each([
-    {
-      platform: 'unix',
-      configLocationPath: '/projects/dummy-project',
-      expectedGlobs: [
-        {
-          ignores: ['/projects/dummy-project/src/entities', '/projects/dummy-project/**/shared'],
+  it.runIf(platform === 'win32')(`should convert relative globs to absolute`, () => {
+    const config: Config<Array<Rule>> = [
+      {
+        ignores: ['./src/entities/**'],
+      },
+      {
+        rules: {
+          rule1: 'warn',
         },
-        {
-          rules: {
-            rule1: 'warn',
-          },
-          files: ['/projects/dummy-project/src/shared/ui', '/projects/dummy-project/**/pages'],
-          ignores: ['/projects/dummy-project/src/shared/ui/index.ts'],
+        files: ['./src/shared/ui/**/*'],
+        ignores: ['./src/shared/ui/index.ts'],
+      },
+    ]
+
+    expect(transformGlobs(config, 'C:/projects/dummy-project')).toEqual([
+      {
+        ignores: ['C:/projects/dummy-project/src/entities/**'],
+      },
+      {
+        rules: {
+          rule1: 'warn',
         },
-      ],
-    },
-    {
-      platform: 'windows',
-      configLocationPath: 'C:/projects/dummy-project',
-      expectedGlobs: [
-        {
-          ignores: ['C:/projects/dummy-project/src/entities', 'C:/projects/dummy-project/**/shared'],
-        },
-        {
-          rules: {
-            rule1: 'warn',
-          },
-          files: ['C:/projects/dummy-project/src/shared/ui', 'C:/projects/dummy-project/**/pages'],
-          ignores: ['C:/projects/dummy-project/src/shared/ui/index.ts'],
-        },
-      ],
-    },
-  ])('should strip trailing slashes on $platform', ({ platform, configLocationPath, expectedGlobs }) => {
-    globalPlatform = platform
+        files: ['C:/projects/dummy-project/src/shared/ui/**/*'],
+        ignores: ['C:/projects/dummy-project/src/shared/ui/index.ts'],
+      },
+    ])
+  })
+
+  it.runIf(platform === 'linux')('should strip trailing slashes', () => {
     const config: Config<Array<Rule>> = [
       {
         ignores: ['./src/entities/', '**/shared/'],
@@ -117,46 +75,51 @@ describe('transformGlobs', () => {
       },
     ]
 
-    expect(transformGlobs(config, configLocationPath)).toEqual(expectedGlobs)
+    expect(transformGlobs(config, '/projects/dummy-project')).toEqual([
+      {
+        ignores: ['/projects/dummy-project/src/entities', '/projects/dummy-project/**/shared'],
+      },
+      {
+        rules: {
+          rule1: 'warn',
+        },
+        files: ['/projects/dummy-project/src/shared/ui', '/projects/dummy-project/**/pages'],
+        ignores: ['/projects/dummy-project/src/shared/ui/index.ts'],
+      },
+    ])
   })
 
-  it.each([
-    {
-      platform: 'unix',
-      configLocationPath: '/projects/dummy-project',
-      expectedGlobs: [
-        {
-          ignores: ['/projects/dummy-project/src/entities/**'],
+  it.runIf(platform === 'win32')('should strip trailing slashes', () => {
+    const config: Config<Array<Rule>> = [
+      {
+        ignores: ['./src/entities/', '**/shared/'],
+      },
+      {
+        rules: {
+          rule1: 'warn',
         },
-        {
-          rules: {
-            rule1: 'warn',
-          },
-          files: ['/projects/dummy-project/src/shared/ui/**/*'],
-          ignores: ['/projects/dummy-project/src/shared/ui/index.ts'],
+        files: ['./src/shared/ui/', '**/pages/'],
+        ignores: ['./src/shared/ui/index.ts'],
+      },
+    ]
+
+    expect(transformGlobs(config, 'C:/projects/dummy-project')).toEqual([
+      {
+        ignores: ['C:/projects/dummy-project/src/entities', 'C:/projects/dummy-project/**/shared'],
+      },
+      {
+        rules: {
+          rule1: 'warn',
         },
-      ],
-    },
-    {
-      platform: 'windows',
-      configLocationPath: 'C:/projects/dummy-project',
-      expectedGlobs: [
-        {
-          ignores: ['C:/projects/dummy-project/src/entities/**'],
-        },
-        {
-          rules: {
-            rule1: 'warn',
-          },
-          files: ['C:/projects/dummy-project/src/shared/ui/**/*'],
-          ignores: ['C:/projects/dummy-project/src/shared/ui/index.ts'],
-        },
-      ],
-    },
-  ])(
-    "should correctly transform globs that are relative but don't start with a dot on $platform",
-    ({ platform, configLocationPath, expectedGlobs }) => {
-      globalPlatform = platform
+        files: ['C:/projects/dummy-project/src/shared/ui', 'C:/projects/dummy-project/**/pages'],
+        ignores: ['C:/projects/dummy-project/src/shared/ui/index.ts'],
+      },
+    ])
+  })
+
+  it.runIf(platform === 'linux')(
+    "should correctly transform globs that are relative but don't start with a dot",
+    () => {
       const config: Config<Array<Rule>> = [
         {
           ignores: ['src/entities/**'],
@@ -170,45 +133,53 @@ describe('transformGlobs', () => {
         },
       ]
 
-      expect(transformGlobs(config, configLocationPath)).toEqual(expectedGlobs)
+      expect(transformGlobs(config, '/projects/dummy-project')).toEqual([
+        {
+          ignores: ['/projects/dummy-project/src/entities/**'],
+        },
+        {
+          rules: {
+            rule1: 'warn',
+          },
+          files: ['/projects/dummy-project/src/shared/ui/**/*'],
+          ignores: ['/projects/dummy-project/src/shared/ui/index.ts'],
+        },
+      ])
     },
   )
 
-  it.each([
-    {
-      platform: 'unix',
-      configLocationPath: '/projects/dummy-project',
-      expectedGlobs: [
+  it.runIf(platform === 'win32')(
+    "should correctly transform globs that are relative but don't start with a dot",
+    () => {
+      const config: Config<Array<Rule>> = [
         {
-          ignores: ['!/projects/dummy-project/src/entities/**'],
+          ignores: ['src/entities/**'],
         },
         {
           rules: {
             rule1: 'warn',
           },
-          files: ['!/projects/dummy-project/**/shared/ui/**/*'],
-          ignores: ['!/projects/dummy-project/src/shared/ui/index.ts'],
+          files: ['src/shared/ui/**/*'],
+          ignores: ['src/shared/ui/index.ts'],
         },
-      ],
-    },
-    {
-      platform: 'windows',
-      configLocationPath: 'C:/projects/dummy-project',
-      expectedGlobs: [
+      ]
+
+      expect(transformGlobs(config, 'C:/projects/dummy-project')).toEqual([
         {
-          ignores: ['!C:/projects/dummy-project/src/entities/**'],
+          ignores: ['C:/projects/dummy-project/src/entities/**'],
         },
         {
           rules: {
             rule1: 'warn',
           },
-          files: ['!C:/projects/dummy-project/**/shared/ui/**/*'],
-          ignores: ['!C:/projects/dummy-project/src/shared/ui/index.ts'],
+          files: ['C:/projects/dummy-project/src/shared/ui/**/*'],
+          ignores: ['C:/projects/dummy-project/src/shared/ui/index.ts'],
         },
-      ],
+      ])
     },
-  ])('should correctly transform negated globs on $platform', ({ platform, configLocationPath, expectedGlobs }) => {
-    globalPlatform = platform
+  )
+
+  it.runIf(platform === 'linux')('should correctly transform negated globs', () => {
     const config: Config<Array<Rule>> = [
       {
         ignores: ['!src/entities/**'],
@@ -222,6 +193,45 @@ describe('transformGlobs', () => {
       },
     ]
 
-    expect(transformGlobs(config, configLocationPath)).toEqual(expectedGlobs)
+    expect(transformGlobs(config, '/projects/dummy-project')).toEqual([
+      {
+        ignores: ['!/projects/dummy-project/src/entities/**'],
+      },
+      {
+        rules: {
+          rule1: 'warn',
+        },
+        files: ['!/projects/dummy-project/**/shared/ui/**/*'],
+        ignores: ['!/projects/dummy-project/src/shared/ui/index.ts'],
+      },
+    ])
+  })
+
+  it.runIf(platform === 'win32')('should correctly transform negated globs', () => {
+    const config: Config<Array<Rule>> = [
+      {
+        ignores: ['!src/entities/**'],
+      },
+      {
+        rules: {
+          rule1: 'warn',
+        },
+        files: ['!**/shared/ui/**/*'],
+        ignores: ['!src/shared/ui/index.ts'],
+      },
+    ]
+
+    expect(transformGlobs(config, 'C:/projects/dummy-project')).toEqual([
+      {
+        ignores: ['!C:/projects/dummy-project/src/entities/**'],
+      },
+      {
+        rules: {
+          rule1: 'warn',
+        },
+        files: ['!C:/projects/dummy-project/**/shared/ui/**/*'],
+        ignores: ['!C:/projects/dummy-project/src/shared/ui/index.ts'],
+      },
+    ])
   })
 })

--- a/packages/steiger/src/models/config/transform-globs.ts
+++ b/packages/steiger/src/models/config/transform-globs.ts
@@ -1,24 +1,17 @@
-import { posix, sep, isAbsolute } from 'node:path'
+import { isAbsolute, resolve } from 'node:path'
 import { Config, Rule } from '@steiger/types'
 
 import { isConfigObject, isConfiguration } from './raw-config'
 import { getGlobPath, replaceGlobPath } from '../../shared/globs'
 
 function convertRelativeGlobsToAbsolute(rootPath: string, globs: Array<string>) {
-  function composeAbsolutePath(root: string, glob: string) {
-    // Remove '/'. The root has platform-specific separators
-    const segmentsOfRoot = root.slice(1).split(sep)
-
-    return `/${posix.join(...segmentsOfRoot, glob)}`
-  }
-
   const needsConversion = (glob: string) => !isAbsolute(glob)
 
   return globs.map((originalGlob) => {
     const globClearPath = getGlobPath(originalGlob)
 
     return needsConversion(globClearPath)
-      ? replaceGlobPath(originalGlob, composeAbsolutePath(rootPath, globClearPath))
+      ? replaceGlobPath(originalGlob, resolve(rootPath, globClearPath).replace(/\\/g, '/'))
       : originalGlob
   })
 }


### PR DESCRIPTION
Hey! 
My version of tests looks a bit overwhelming, I also thought about a simple function that would take a platform parameter and depending on the value would prepend `C`:, but I'm not sure if that's the right way to do tests. However, if you think otherwise, I can rework it (or am open to any other suggestions)