### PR TITLE
Make the README less confusing (for now)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,24 +118,23 @@ Currently, Steiger is not extendable with more rules, though that will change in
   </tr>
 </thead>
 <tbody>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/ambiguous-slice-names/README.md"><code>ambiguous-slice-names</code></a></td> <td>Forbid slice names that that match some segment’s name in the Shared layer.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/excessive-slicing/README.md"><code>excessive-slicing</code></a></td> <td>Forbid having too many ungrouped slices or too many slices in a group.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/forbidden-imports/README.md"><code>forbidden-imports</code></a></td> <td>Forbid imports from higher layers and cross-imports between slices on the same layer.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/inconsistent-naming/README.md"><code>inconsistent-naming</code></a></td> <td>Ensure that all entities are named consistently in terms of pluralization.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/insignificant-slice/README.md"><code>insignificant-slice</code></a></td> <td>Detect slices that have just one reference or no references to them at all.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-layer-public-api/README.md"><code>no-layer-public-api</code></a></td> <td>Forbid index files on the layer level.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-public-api-sidestep/README.md"><code>no-public-api-sidestep</code></a></td> <td>Forbid going around the public API of a slice to import directly from an internal module in a slice.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-reserved-folder-names/README.md"><code>no-reserved-folder-names</code></a></td> <td>Forbid subfolders in segments that have the same name as other conventional segments.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-segmentless-slices/README.md"><code>no-segmentless-slices</code></a></td> <td>Forbid slices that don't have any segments.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-segments-on-sliced-layers/README.md"><code>no-segments-on-sliced-layers</code></a></td> <td>Forbid segments (like ui, lib, api ...) that appear directly in sliced layer folders (entities, features, ...)</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-ui-in-app/README.md"><code>no-ui-in-app</code></a></td> <td>Forbid having the <code>ui</code> segment on the App layer.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/public-api/README.md"><code>public-api</code></a></td> <td>Require slices (and segments on sliceless layers like Shared) to have a public API definition.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/repetitive-naming/README.md"><code>repetitive-naming</code></a></td> <td>Ensure that all entities are named consistently in terms of pluralization.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/segments-by-purpose/README.md"><code>segments-by-purpose</code></a></td> <td>Discourage the use of segment names that group code by its essence, and instead encourage grouping by purpose</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/shared-lib-grouping/README.md"><code>shared-lib-grouping</code></a></td> <td>Forbid having too many ungrouped modules in <code>shared/lib</code>.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/typo-in-layer-name/README.md"><code>typo-in-layer-name</code></a></td> <td>Ensure that all layers are named without any typos.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-processes/README.md"><code>no-processes</code></a></td> <td>Discourage the use of the deprecated Processes layer.</td> </tr>
-  <tr> <td><a href="./packages/steiger-plugin-fsd/src/import-locality/README.md"><code>import-locality</code></a></td> <td>Require that imports from the same slice be relative and imports from one slice to another be absolute.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/ambiguous-slice-names/README.md"><code>fsd/ambiguous-slice-names</code></a></td> <td>Forbid slice names that that match some segment’s name in the Shared layer.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/excessive-slicing/README.md"><code>fsd/excessive-slicing</code></a></td> <td>Forbid having too many ungrouped slices or too many slices in a group.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/forbidden-imports/README.md"><code>fsd/forbidden-imports</code></a></td> <td>Forbid imports from higher layers and cross-imports between slices on the same layer.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/inconsistent-naming/README.md"><code>fsd/inconsistent-naming</code></a></td> <td>Ensure that all entities are named consistently in terms of pluralization.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/insignificant-slice/README.md"><code>fsd/insignificant-slice</code></a></td> <td>Detect slices that have just one reference or no references to them at all.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-layer-public-api/README.md"><code>fsd/no-layer-public-api</code></a></td> <td>Forbid index files on the layer level.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-public-api-sidestep/README.md"><code>fsd/no-public-api-sidestep</code></a></td> <td>Forbid going around the public API of a slice to import directly from an internal module in a slice.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-reserved-folder-names/README.md"><code>fsd/no-reserved-folder-names</code></a></td> <td>Forbid subfolders in segments that have the same name as other conventional segments.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-segmentless-slices/README.md"><code>fsd/no-segmentless-slices</code></a></td> <td>Forbid slices that don't have any segments.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-segments-on-sliced-layers/README.md"><code>fsd/no-segments-on-sliced-layers</code></a></td> <td>Forbid segments (like ui, lib, api ...) that appear directly in sliced layer folders (entities, features, ...)</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-ui-in-app/README.md"><code>fsd/no-ui-in-app</code></a></td> <td>Forbid having the <code>ui</code> segment on the App layer.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/public-api/README.md"><code>fsd/public-api</code></a></td> <td>Require slices (and segments on sliceless layers like Shared) to have a public API definition.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/repetitive-naming/README.md"><code>fsd/repetitive-naming</code></a></td> <td>Ensure that all entities are named consistently in terms of pluralization.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/segments-by-purpose/README.md"><code>fsd/segments-by-purpose</code></a></td> <td>Discourage the use of segment names that group code by its essence, and instead encourage grouping by purpose</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/shared-lib-grouping/README.md"><code>fsd/shared-lib-grouping</code></a></td> <td>Forbid having too many ungrouped modules in <code>shared/lib</code>.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/typo-in-layer-name/README.md"><code>fsd/typo-in-layer-name</code></a></td> <td>Ensure that all layers are named without any typos.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-processes/README.md"><code>fsd/no-processes</code></a></td> <td>Discourage the use of the deprecated Processes layer.</td> </tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
It might be a while until we do the next release including `import-locality`, so for the time being I'll remove that rule from the README. I'll also add the `fsd/` prefix to make it clearer what the actual full names of the rules are.

Deliberately didn't bother updating the other README, since this is a temporary PR. Also addresses #142 