### PR TITLE
Move getRuleDescriptionUrl to plugins

### DIFF
--- a/.changeset/two-dragons-report.md
+++ b/.changeset/two-dragons-report.md
@@ -1,0 +1,7 @@
+---
+'@feature-sliced/steiger-plugin': minor
+'steiger': minor
+'@steiger/types': minor
+---
+
+Move getRuleDescriptionUrl from Steiger core to plugins

--- a/packages/pretty-reporter/example/index.ts
+++ b/packages/pretty-reporter/example/index.ts
@@ -56,8 +56,12 @@ reportPretty(
       severity: 'error',
       getRuleDescriptionUrl,
     },
+    {
+      message: 'Example of a diagnostic without a description URL',
+      ruleName: 'dummy/rule-name',
+      location: { path: '/home/user/project/src/pages' },
+      severity: 'error',
+    },
   ],
   '/home/user/project',
 )
-
-// reportPretty([], '/home/user/project')

--- a/packages/pretty-reporter/src/format-single-diagnostic.ts
+++ b/packages/pretty-reporter/src/format-single-diagnostic.ts
@@ -12,7 +12,9 @@ export function formatSingleDiagnostic(d: Diagnostic, cwd: string): string {
   const message = chalk.reset(d.message)
   const autofixable = d.fixes !== undefined && d.fixes.length > 0 ? chalk.green(`${figures.tick} Auto-fixable`) : null
   const location = chalk.gray(formatLocation(d.location, cwd))
-  const ruleName = chalk.blue(terminalLink(d.ruleName, d.getRuleDescriptionUrl(d.ruleName).toString()))
+  const ruleName = d.getRuleDescriptionUrl
+    ? chalk.blue(terminalLink(d.ruleName, d.getRuleDescriptionUrl(d.ruleName).toString()))
+    : chalk.reset(d.ruleName)
 
   return `
 ${s} ${location}

--- a/packages/steiger-plugin-fsd/src/index.ts
+++ b/packages/steiger-plugin-fsd/src/index.ts
@@ -19,6 +19,8 @@ import typoInLayerName from './typo-in-layer-name/index.js'
 import noProcesses from './no-processes/index.js'
 import packageJson from '../package.json'
 
+const FSD_RULE_DESC_SOURCE = 'https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/'
+
 const rules = [
   ambiguousSliceNames,
   excessiveSlicing,
@@ -43,6 +45,10 @@ const plugin = createPlugin({
   meta: {
     name: '@feature-sliced/steiger-plugin',
     version: packageJson.version,
+  },
+  getRuleDescriptionUrl(ruleName: string) {
+    const ruleNameWithoutNamespace = ruleName.split('/')[1]
+    return new URL(`${FSD_RULE_DESC_SOURCE}${ruleNameWithoutNamespace}`)
   },
   ruleDefinitions: rules,
 })

--- a/packages/steiger/src/app.ts
+++ b/packages/steiger/src/app.ts
@@ -20,7 +20,7 @@ async function runRules({ vfs, rules }: { vfs: Folder; rules: Array<Rule> }) {
     }
 
     const ruleName = rules[ruleResultsIndex].name
-    const pluginProvidedTheRule = getPluginByRuleName(ruleName)
+    const ruleSourcePlugin = getPluginByRuleName(ruleName)
     const severities = calculateFinalSeverities(
       vfsWithoutGlobalIgnores,
       ruleName,

--- a/packages/steiger/src/app.ts
+++ b/packages/steiger/src/app.ts
@@ -4,18 +4,10 @@ import type { Config, Folder, Rule } from '@steiger/types'
 
 import { scan, createWatcher } from './features/transfer-fs-to-vfs'
 import { defer } from './shared/defer'
-import { $enabledRules, getEnabledRules, getGlobalIgnores } from './models/config'
+import { $enabledRules, getEnabledRules, getGlobalIgnores, getPluginByRuleName } from './models/config'
 import { runRule } from './features/run-rule'
 import { removeGlobalIgnoreFromVfs } from './features/remove-global-ignores-from-vfs'
 import { calculateFinalSeverities } from './features/calculate-diagnostic-severities'
-
-// TODO: make this part of a plugin
-function getRuleDescriptionUrl(ruleName: string) {
-  const withoutNamespace = ruleName.split('/')[1]
-  return new URL(
-    `https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/${withoutNamespace}`,
-  )
-}
 
 async function runRules({ vfs, rules }: { vfs: Folder; rules: Array<Rule> }) {
   const vfsWithoutGlobalIgnores = removeGlobalIgnoreFromVfs(vfs, getGlobalIgnores())
@@ -28,6 +20,7 @@ async function runRules({ vfs, rules }: { vfs: Folder; rules: Array<Rule> }) {
     }
 
     const ruleName = rules[ruleResultsIndex].name
+    const pluginProvidedTheRule = getPluginByRuleName(ruleName)
     const severities = calculateFinalSeverities(
       vfsWithoutGlobalIgnores,
       ruleName,
@@ -37,7 +30,7 @@ async function runRules({ vfs, rules }: { vfs: Folder; rules: Array<Rule> }) {
     return diagnostics.map((d, index) => ({
       ...d,
       ruleName,
-      getRuleDescriptionUrl,
+      getRuleDescriptionUrl: pluginProvidedTheRule.getRuleDescriptionUrl,
       severity: severities[index],
     }))
   })

--- a/packages/steiger/src/app.ts
+++ b/packages/steiger/src/app.ts
@@ -27,12 +27,22 @@ async function runRules({ vfs, rules }: { vfs: Folder; rules: Array<Rule> }) {
       diagnostics.map((d) => d.location.path),
     )
 
-    return diagnostics.map((d, index) => ({
-      ...d,
-      ruleName,
-      getRuleDescriptionUrl: ruleSourcePlugin.getRuleDescriptionUrl,
-      severity: severities[index],
-    }))
+    return diagnostics.map((d, index) => {
+      const finalDiagnostic = {
+        ...d,
+        ruleName,
+        severity: severities[index],
+      }
+
+      if (ruleSourcePlugin.getRuleDescriptionUrl) {
+        return {
+          ...finalDiagnostic,
+          getRuleDescriptionUrl: ruleSourcePlugin.getRuleDescriptionUrl,
+        }
+      }
+
+      return finalDiagnostic
+    })
   })
 }
 

--- a/packages/steiger/src/app.ts
+++ b/packages/steiger/src/app.ts
@@ -30,7 +30,7 @@ async function runRules({ vfs, rules }: { vfs: Folder; rules: Array<Rule> }) {
     return diagnostics.map((d, index) => ({
       ...d,
       ruleName,
-      getRuleDescriptionUrl: pluginProvidedTheRule.getRuleDescriptionUrl,
+      getRuleDescriptionUrl: ruleSourcePlugin.getRuleDescriptionUrl,
       severity: severities[index],
     }))
   })

--- a/packages/steiger/src/models/config/index.ts
+++ b/packages/steiger/src/models/config/index.ts
@@ -49,12 +49,13 @@ export function getEnabledRules() {
 }
 
 export function getPluginByRuleName(ruleName: string) {
-  // Always returns a plugin because if a rule exists than the plugin provided it must exist too
-  const sourcePlugin = $plugins.getState().find((plugin) => plugin.ruleDefinitions.some((rule) => rule.name === ruleName))
+  const sourcePlugin = $plugins
+    .getState()
+    .find((plugin) => plugin.ruleDefinitions.some((rule) => rule.name === ruleName))
   if (sourcePlugin === undefined) {
     throw new Error(`Expected to find a source plugin for the rule "${ruleName}", but didn't`)
   }
-  
+
   return sourcePlugin
 }
 

--- a/packages/steiger/src/models/config/index.ts
+++ b/packages/steiger/src/models/config/index.ts
@@ -50,7 +50,12 @@ export function getEnabledRules() {
 
 export function getPluginByRuleName(ruleName: string) {
   // Always returns a plugin because if a rule exists than the plugin provided it must exist too
-  return $plugins.getState().find((plugin) => plugin.ruleDefinitions.some((rule) => rule.name === ruleName))!
+  const sourcePlugin = $plugins.getState().find((plugin) => plugin.ruleDefinitions.some((rule) => rule.name === ruleName))
+  if (sourcePlugin === undefined) {
+    throw new Error(`Expected to find a source plugin for the rule "${ruleName}", but didn't`)
+  }
+  
+  return sourcePlugin
 }
 
 export function getRuleOptions(ruleName: string) {

--- a/packages/steiger/src/models/config/index.ts
+++ b/packages/steiger/src/models/config/index.ts
@@ -48,6 +48,11 @@ export function getEnabledRules() {
   return $enabledRules.getState()
 }
 
+export function getPluginByRuleName(ruleName: string) {
+  // Always returns a plugin because if a rule exists than the plugin provided it must exist too
+  return $plugins.getState().find((plugin) => plugin.ruleDefinitions.some((rule) => rule.name === ruleName))!
+}
+
 export function getRuleOptions(ruleName: string) {
   return $ruleInstructions.getState()?.[ruleName].options || null
 }

--- a/packages/steiger/src/models/config/validate-config.spec.ts
+++ b/packages/steiger/src/models/config/validate-config.spec.ts
@@ -3,7 +3,7 @@ import { Config, Plugin, Rule } from '@steiger/types'
 
 import { buildValidationScheme, validateConfig } from './validate-config'
 
-const dummyPlugin: Plugin = {
+const dummyPluginWithGetRuleDescriptionUrl: Plugin = {
   meta: {
     name: 'dummy',
     version: '1.0.0',
@@ -27,10 +27,31 @@ const dummyPlugin: Plugin = {
   ],
 }
 
+const dummyPluginWithoutGetRuleDescriptionUrl: Plugin = {
+  meta: {
+    name: 'dummy',
+    version: '1.0.0',
+  },
+  ruleDefinitions: [
+    {
+      name: 'rule1',
+      check() {
+        return { diagnostics: [] }
+      },
+    },
+    {
+      name: 'rule2',
+      check() {
+        return { diagnostics: [] }
+      },
+    },
+  ],
+}
+
 describe('buildValidationScheme', () => {
   it('should successfully validate config with plain severities', () => {
     const config = [
-      dummyPlugin,
+      dummyPluginWithGetRuleDescriptionUrl,
       {
         rules: {
           rule1: 'off',
@@ -45,7 +66,7 @@ describe('buildValidationScheme', () => {
 
   it('should successfully validate config with a tuple of severity and rule options', () => {
     const config = [
-      dummyPlugin,
+      dummyPluginWithoutGetRuleDescriptionUrl,
       {
         rules: {
           rule1: ['warn', {}],
@@ -60,7 +81,7 @@ describe('buildValidationScheme', () => {
 
   it('should successfully validate a config with several objects', () => {
     const config = [
-      dummyPlugin,
+      dummyPluginWithGetRuleDescriptionUrl,
       {
         rules: {
           rule1: 'off',
@@ -80,7 +101,7 @@ describe('buildValidationScheme', () => {
 
   it('should successfully validate a config with ignores', () => {
     const config = [
-      dummyPlugin,
+      dummyPluginWithGetRuleDescriptionUrl,
       {
         ignores: ['/shared'],
         rules: {
@@ -101,7 +122,7 @@ describe('buildValidationScheme', () => {
 
   it('should successfully validate a config with files', () => {
     const config = [
-      dummyPlugin,
+      dummyPluginWithGetRuleDescriptionUrl,
 
       {
         files: ['/shared'],
@@ -123,7 +144,7 @@ describe('buildValidationScheme', () => {
 
   it('should successfully validate a config with files and ignores', () => {
     const config = [
-      dummyPlugin,
+      dummyPluginWithGetRuleDescriptionUrl,
       {
         files: ['/shared'],
         ignores: ['**/*.test.ts'],
@@ -156,16 +177,16 @@ describe('buildValidationScheme', () => {
   })
 
   it('should throw an error if no config objects are provided', () => {
-    const config = [dummyPlugin] as Config<Array<Rule>>
+    const config = [dummyPluginWithGetRuleDescriptionUrl] as Config<Array<Rule>>
     const scheme = buildValidationScheme(config)
 
     expect(() => scheme.parse(config)).toThrow('At least one config object must be provided!')
   })
 
   it('should throw an error if a config object without rules is provided', () => {
-    const config = [dummyPlugin, {}] as Config<Array<Rule>>
-    const config1 = [dummyPlugin, { files: ['/shared'] }] as Config<Array<Rule>>
-    const config2 = [dummyPlugin, { ignores: ['**/*.test.ts'] }] as Config<Array<Rule>>
+    const config = [dummyPluginWithGetRuleDescriptionUrl, {}] as Config<Array<Rule>>
+    const config1 = [dummyPluginWithGetRuleDescriptionUrl, { files: ['/shared'] }] as Config<Array<Rule>>
+    const config2 = [dummyPluginWithGetRuleDescriptionUrl, { ignores: ['**/*.test.ts'] }] as Config<Array<Rule>>
 
     const scheme = buildValidationScheme(config)
     const scheme1 = buildValidationScheme(config1)
@@ -178,7 +199,7 @@ describe('buildValidationScheme', () => {
 
   it('should throw an error if a non-existent rule is provided', () => {
     const config = [
-      dummyPlugin,
+      dummyPluginWithGetRuleDescriptionUrl,
       {
         rules: {
           rule1: 'off',
@@ -193,7 +214,7 @@ describe('buildValidationScheme', () => {
 
   it('should correctly validate a config with global ignores', () => {
     const config = [
-      dummyPlugin,
+      dummyPluginWithGetRuleDescriptionUrl,
       {
         ignores: ['/src/shared/**'],
       },
@@ -211,7 +232,7 @@ describe('buildValidationScheme', () => {
 
   it('should correctly validate a config with unique rule options', () => {
     const config = [
-      dummyPlugin,
+      dummyPluginWithGetRuleDescriptionUrl,
       {
         ignores: ['/src/shared/**'],
       },
@@ -229,7 +250,7 @@ describe('buildValidationScheme', () => {
 
   it('should successfully validate when the config provides a rule with multiple but identical options', () => {
     const config: Config<Array<Rule>> = [
-      dummyPlugin,
+      dummyPluginWithGetRuleDescriptionUrl,
       {
         rules: {
           rule1: ['warn', { option1: 'value1' }],
@@ -250,7 +271,7 @@ describe('buildValidationScheme', () => {
 
   it('should throw an error when the config provides a rule with multiple but different options', () => {
     const config: Config<Array<Rule>> = [
-      dummyPlugin,
+      dummyPluginWithGetRuleDescriptionUrl,
       {
         rules: {
           rule1: ['warn', { option1: 'value1' }],
@@ -276,8 +297,8 @@ describe('buildValidationScheme', () => {
 
   it('should throw an error when duplicate rule definition are provided', () => {
     const config: Config<Array<Rule>> = [
-      dummyPlugin,
-      dummyPlugin,
+      dummyPluginWithGetRuleDescriptionUrl,
+      dummyPluginWithGetRuleDescriptionUrl,
       {
         rules: {
           rule1: ['warn', { option1: 'value1' }],

--- a/packages/steiger/src/models/config/validate-config.spec.ts
+++ b/packages/steiger/src/models/config/validate-config.spec.ts
@@ -8,11 +8,12 @@ import { isPlugin } from './raw-config'
 // but with the check method expected to be just any function.
 // The reason why it's needed is that the original check method's .toString method returns [Function: check],
 // but after the validation it changes to [Function: anonymous] and fails the test.
-function expectCheckToBeAnyFunction(config: Config<Array<Rule>>) {
+function expectFunctionsToBeAnyFunction(config: Config<Array<Rule>>) {
   return config.map((configObject) => {
     if (isPlugin(configObject)) {
       return {
         ...configObject,
+        getRuleDescriptionUrl: expect.any(Function),
         ruleDefinitions: configObject.ruleDefinitions.map((ruleDefinition) => ({
           ...ruleDefinition,
           check: expect.any(Function),
@@ -27,6 +28,9 @@ const dummyPlugin: Plugin = {
   meta: {
     name: 'dummy',
     version: '1.0.0',
+  },
+  getRuleDescriptionUrl(ruleName: string): URL {
+    return new URL(`http://example.com/${ruleName}`)
   },
   ruleDefinitions: [
     {
@@ -57,7 +61,7 @@ describe('buildValidationScheme', () => {
     ] as Config<Array<Rule>>
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectCheckToBeAnyFunction(config))
+    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
   })
 
   it('should successfully validate config with a tuple of severity and rule options', () => {
@@ -72,7 +76,7 @@ describe('buildValidationScheme', () => {
     ] as Config<Array<Rule>>
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectCheckToBeAnyFunction(config))
+    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
   })
 
   it('should successfully validate a config with several objects', () => {
@@ -92,7 +96,7 @@ describe('buildValidationScheme', () => {
 
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectCheckToBeAnyFunction(config))
+    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
   })
 
   it('should successfully validate a config with ignores', () => {
@@ -113,7 +117,7 @@ describe('buildValidationScheme', () => {
     ] as Config<Array<Rule>>
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectCheckToBeAnyFunction(config))
+    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
   })
 
   it('should successfully validate a config with files', () => {
@@ -135,7 +139,7 @@ describe('buildValidationScheme', () => {
     ] as Config<Array<Rule>>
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectCheckToBeAnyFunction(config))
+    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
   })
 
   it('should successfully validate a config with files and ignores', () => {
@@ -158,7 +162,7 @@ describe('buildValidationScheme', () => {
     ] as Config<Array<Rule>>
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectCheckToBeAnyFunction(config))
+    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
   })
 
   it('should throw an error if no plugins are provided', () => {
@@ -223,7 +227,7 @@ describe('buildValidationScheme', () => {
     ]
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectCheckToBeAnyFunction(config))
+    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
   })
 
   it('should correctly validate a config with unique rule options', () => {
@@ -241,7 +245,7 @@ describe('buildValidationScheme', () => {
     ]
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectCheckToBeAnyFunction(config))
+    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
   })
 
   it('should successfully validate when the config provides a rule with multiple but identical options', () => {
@@ -262,7 +266,7 @@ describe('buildValidationScheme', () => {
     ]
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectCheckToBeAnyFunction(config))
+    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
   })
 
   it('should throw an error when the config provides a rule with multiple but different options', () => {

--- a/packages/steiger/src/models/config/validate-config.spec.ts
+++ b/packages/steiger/src/models/config/validate-config.spec.ts
@@ -2,27 +2,6 @@ import { describe, expect, it } from 'vitest'
 import { Config, Plugin, Rule } from '@steiger/types'
 
 import { buildValidationScheme, validateConfig } from './validate-config'
-import { isPlugin } from './raw-config'
-
-// The function maps a plugin object to a new object with the same properties as the original object,
-// but with the check method expected to be just any function.
-// The reason why it's needed is that the original check method's .toString method returns [Function: check],
-// but after the validation it changes to [Function: anonymous] and fails the test.
-function expectFunctionsToBeAnyFunction(config: Config<Array<Rule>>) {
-  return config.map((configObject) => {
-    if (isPlugin(configObject)) {
-      return {
-        ...configObject,
-        getRuleDescriptionUrl: expect.any(Function),
-        ruleDefinitions: configObject.ruleDefinitions.map((ruleDefinition) => ({
-          ...ruleDefinition,
-          check: expect.any(Function),
-        })),
-      }
-    }
-    return configObject
-  })
-}
 
 const dummyPlugin: Plugin = {
   meta: {
@@ -61,7 +40,7 @@ describe('buildValidationScheme', () => {
     ] as Config<Array<Rule>>
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
+    expect(() => scheme.parse(config)).not.toThrow()
   })
 
   it('should successfully validate config with a tuple of severity and rule options', () => {
@@ -76,7 +55,7 @@ describe('buildValidationScheme', () => {
     ] as Config<Array<Rule>>
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
+    expect(() => scheme.parse(config)).not.toThrow()
   })
 
   it('should successfully validate a config with several objects', () => {
@@ -96,7 +75,7 @@ describe('buildValidationScheme', () => {
 
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
+    expect(() => scheme.parse(config)).not.toThrow()
   })
 
   it('should successfully validate a config with ignores', () => {
@@ -117,7 +96,7 @@ describe('buildValidationScheme', () => {
     ] as Config<Array<Rule>>
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
+    expect(() => scheme.parse(config)).not.toThrow()
   })
 
   it('should successfully validate a config with files', () => {
@@ -139,7 +118,7 @@ describe('buildValidationScheme', () => {
     ] as Config<Array<Rule>>
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
+    expect(() => scheme.parse(config)).not.toThrow()
   })
 
   it('should successfully validate a config with files and ignores', () => {
@@ -162,7 +141,7 @@ describe('buildValidationScheme', () => {
     ] as Config<Array<Rule>>
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
+    expect(() => scheme.parse(config)).not.toThrow()
   })
 
   it('should throw an error if no plugins are provided', () => {
@@ -227,7 +206,7 @@ describe('buildValidationScheme', () => {
     ]
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
+    expect(() => scheme.parse(config)).not.toThrow()
   })
 
   it('should correctly validate a config with unique rule options', () => {
@@ -245,7 +224,7 @@ describe('buildValidationScheme', () => {
     ]
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
+    expect(() => scheme.parse(config)).not.toThrow()
   })
 
   it('should successfully validate when the config provides a rule with multiple but identical options', () => {
@@ -266,7 +245,7 @@ describe('buildValidationScheme', () => {
     ]
     const scheme = buildValidationScheme(config)
 
-    expect(scheme.parse(config)).toEqual(expectFunctionsToBeAnyFunction(config))
+    expect(() => scheme.parse(config)).not.toThrow()
   })
 
   it('should throw an error when the config provides a rule with multiple but different options', () => {

--- a/packages/steiger/src/models/config/validate-config.ts
+++ b/packages/steiger/src/models/config/validate-config.ts
@@ -114,6 +114,7 @@ export function buildValidationScheme(rawConfig: Config<Array<Rule>>) {
             name: z.string(),
             version: z.string(),
           }),
+          getRuleDescriptionUrl: z.function().args(z.string()).returns(z.any()),
           ruleDefinitions: z.array(
             z.object({
               name: z.string(),

--- a/packages/steiger/src/models/config/validate-config.ts
+++ b/packages/steiger/src/models/config/validate-config.ts
@@ -114,7 +114,7 @@ export function buildValidationScheme(rawConfig: Config<Array<Rule>>) {
             name: z.string(),
             version: z.string(),
           }),
-          getRuleDescriptionUrl: z.function().args(z.string()).returns(z.any()),
+          getRuleDescriptionUrl: z.optional(z.function().args(z.string()).returns(z.any())),
           ruleDefinitions: z.array(
             z.object({
               name: z.string(),

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -112,5 +112,6 @@ export interface Plugin<Context = unknown, Rules extends Array<Rule<Context>> = 
     name: string
     version: string
   }
+  getRuleDescriptionUrl(ruleName: string): URL
   ruleDefinitions: Rules
 }

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -39,7 +39,7 @@ export interface PartialDiagnostic {
 export interface Diagnostic extends PartialDiagnostic {
   ruleName: string
   severity: Exclude<Severity, 'off'>
-  getRuleDescriptionUrl(ruleName: string): URL
+  getRuleDescriptionUrl?(ruleName: string): URL
 }
 
 export type Fix =
@@ -112,6 +112,6 @@ export interface Plugin<Context = unknown, Rules extends Array<Rule<Context>> = 
     name: string
     version: string
   }
-  getRuleDescriptionUrl(ruleName: string): URL
+  getRuleDescriptionUrl?(ruleName: string): URL
   ruleDefinitions: Rules
 }


### PR DESCRIPTION
Closes #131

I was not sure about one thing: should `getRuleDescriptionUr`l be an optional plugin method or not? I decided to make it required because otherwise, a diagnostic is not that useful. What do you think?