### PR TITLE
Prevent links to rule descriptions being broken in some terminals

### DIFF
--- a/.changeset/tricky-news-float.md
+++ b/.changeset/tricky-news-float.md
@@ -1,0 +1,5 @@
+---
+'@steiger/pretty-reporter': patch
+---
+
+Prevent links to rule descriptions being broken in some terminals

--- a/packages/pretty-reporter/src/format-single-diagnostic.ts
+++ b/packages/pretty-reporter/src/format-single-diagnostic.ts
@@ -12,7 +12,11 @@ export function formatSingleDiagnostic(d: Diagnostic, cwd: string): string {
   const message = pc.reset(d.message)
   const autofixable = d.fixes !== undefined && d.fixes.length > 0 ? pc.green(`${figures.tick} Auto-fixable`) : null
   const location = pc.underline(formatLocation(d.location, cwd))
-  const ruleName = pc.blue(terminalLink(d.ruleName, d.getRuleDescriptionUrl(d.ruleName).toString()))
+  const ruleName = pc.blue(
+    terminalLink(d.ruleName, d.getRuleDescriptionUrl(d.ruleName).toString(), {
+      fallback: (text, url) => `${pc.reset(text)}: ${pc.blue(url)}`,
+    }),
+  )
 
   return `
 ${s} ${location}


### PR DESCRIPTION
Closes #73. It's not the best it can be, but until we work out a short domain, that should suffice.
<img width="794" alt="image" src="https://github.com/user-attachments/assets/306e3b40-dc5c-4123-b4fd-49aeab6e9d63" />
