### PR TITLE
feat: extend the functionality of `inconsistent-naming`

### DIFF
--- a/.changeset/rude-items-shout.md
+++ b/.changeset/rude-items-shout.md
@@ -1,0 +1,5 @@
+---
+'@feature-sliced/steiger-plugin': minor
+---
+
+Extend the functionality of `inconsistent-naming` to support multi-word names and handle rename collisions

--- a/packages/steiger-plugin-fsd/src/inconsistent-naming/get-main-subject.ts
+++ b/packages/steiger-plugin-fsd/src/inconsistent-naming/get-main-subject.ts
@@ -1,4 +1,5 @@
-import { wordPattern } from '../inconsistent-naming-scheme/detect-naming-scheme.js'
+/** Extracts individual words in every naming scheme. */
+export const wordPattern = /([A-Z0-9]{2,}(?![A-Z][a-z])|[A-Z]?[a-z0-9]+)/g
 
 /**
  * Extract the main subject in a multi-word subject name.

--- a/packages/steiger-plugin-fsd/src/inconsistent-naming/get-main-subject.ts
+++ b/packages/steiger-plugin-fsd/src/inconsistent-naming/get-main-subject.ts
@@ -1,0 +1,90 @@
+import { wordPattern } from '../inconsistent-naming-scheme/detect-naming-scheme.js'
+
+/**
+ * Extract the main subject in a multi-word subject name.
+ *
+ * @example
+ * getMainSubject("a book with pages") // "book"
+ * getMainSubject("admin-users") // "users"
+ * getMainSubject("receiptsByOrder") // "receipts"
+ */
+export function getMainSubject(name: string) {
+  const words = [...name.matchAll(wordPattern)]
+    .map((match) => match[0])
+    .filter((word) => !articles.includes(word.toLocaleLowerCase()))
+
+  const prepositionIndex = words.findIndex((word) => prepositions.includes(word.toLocaleLowerCase()))
+  if (prepositionIndex === -1) {
+    return words[words.length - 1]
+  }
+  const mainPart = words.slice(0, prepositionIndex)
+  return mainPart[mainPart.length - 1]
+}
+
+if (import.meta.vitest) {
+  const { test, expect } = import.meta.vitest
+
+  test('getMainSubject', () => {
+    expect(getMainSubject('a book with pages')).toEqual('book')
+    expect(getMainSubject('admin-users')).toEqual('users')
+    expect(getMainSubject('receiptsByOrder')).toEqual('receipts')
+  })
+}
+
+const articles = ['a', 'an', 'the']
+const prepositions = [
+  'about',
+  'above',
+  'across',
+  'after',
+  'against',
+  'along',
+  'among',
+  'around',
+  'at',
+  'before',
+  'behind',
+  'below',
+  'beneath',
+  'beside',
+  'besides',
+  'between',
+  'beyond',
+  'but',
+  'by',
+  'concerning',
+  'despite',
+  'down',
+  'during',
+  'except',
+  'excepting',
+  'for',
+  'from',
+  'in',
+  'inside',
+  'into',
+  'like',
+  'near',
+  'of',
+  'off',
+  'on',
+  'onto',
+  'out',
+  'outside',
+  'over',
+  'past',
+  'regarding',
+  'since',
+  'through',
+  'throughout',
+  'to',
+  'toward',
+  'under',
+  'underneath',
+  'until',
+  'up',
+  'upon',
+  'with',
+  'within',
+  'without',
+]

--- a/packages/steiger-plugin-fsd/src/inconsistent-naming/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/inconsistent-naming/index.spec.ts
@@ -113,7 +113,7 @@ it('prefers the singular form when there are more singular slices', () => {
   ])
 })
 
-it('recognizes the special case when there are two pluralizations of the same name', () => {
+it('recognizes the special case when there is a plural and singular form of the same name', () => {
   const root = parseIntoFsdRoot(
     `
     📂 entities

--- a/packages/steiger-plugin-fsd/src/inconsistent-naming/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/inconsistent-naming/index.spec.ts
@@ -67,12 +67,12 @@ it('reports an error on entity names that are not pluralized consistently', () =
   const diagnostics = inconsistentNaming.check(root).diagnostics
   expect(diagnostics).toEqual([
     {
-      message: 'Inconsistent pluralization of entity names. Prefer all plural names.',
+      message: 'Inconsistent pluralization of entity names. Prefer all singular names.',
       fixes: [
         {
           type: 'rename',
-          path: joinFromRoot('users', 'user', 'project', 'src', 'entities', 'user'),
-          newName: 'users',
+          path: joinFromRoot('users', 'user', 'project', 'src', 'entities', 'posts'),
+          newName: 'post',
         },
       ],
       location: { path: joinFromRoot('users', 'user', 'project', 'src', 'entities') },

--- a/packages/steiger-plugin-fsd/src/inconsistent-naming/index.ts
+++ b/packages/steiger-plugin-fsd/src/inconsistent-naming/index.ts
@@ -50,7 +50,7 @@ const inconsistentNaming = {
 
         const message = 'Inconsistent pluralization of entity names'
         if (
-          pluralNames.length >= singularNames.length &&
+          pluralNames.length > singularNames.length &&
           singularNames.some(([name]) => !duplicates.singular.includes(name))
         ) {
           diagnostics.push({

--- a/packages/steiger-plugin-fsd/src/inconsistent-naming/index.ts
+++ b/packages/steiger-plugin-fsd/src/inconsistent-naming/index.ts
@@ -49,10 +49,7 @@ const inconsistentNaming = {
         }
 
         const message = 'Inconsistent pluralization of entity names'
-        if (
-          pluralNames.length > singularNames.length &&
-          singularNames.some(([name]) => !duplicates.singular.includes(name))
-        ) {
+        if (pluralNames.length > singularNames.length && singularNames.length > duplicates.singular.length) {
           diagnostics.push({
             message: `${message}. Prefer all plural names.`,
             fixes: singularNames
@@ -64,7 +61,7 @@ const inconsistentNaming = {
               })),
             location: { path: join(entities.path, groupPrefix) },
           })
-        } else if (pluralNames.some(([name]) => !duplicates.plural.includes(name))) {
+        } else if (pluralNames.length > duplicates.plural.length) {
           diagnostics.push({
             message: `${message}. Prefer all singular names.`,
             fixes: pluralNames

--- a/packages/steiger-plugin-fsd/src/inconsistent-naming/index.ts
+++ b/packages/steiger-plugin-fsd/src/inconsistent-naming/index.ts
@@ -7,8 +7,9 @@ import type { PartialDiagnostic, Rule } from '@steiger/toolkit'
 
 import { groupSlices } from '../_lib/group-slices.js'
 import { NAMESPACE } from '../constants.js'
+import { getMainSubject } from './get-main-subject.js'
 
-/** Detect inconsistent naming of slices on layers (singular vs plural) */
+/** Detect inconsistent pluralization of entities. */
 const inconsistentNaming = {
   name: `${NAMESPACE}/inconsistent-naming` as const,
   check(root) {
@@ -22,29 +23,57 @@ const inconsistentNaming = {
     const slices = getSlices(entities)
     const sliceNames = groupSlices(Object.keys(slices))
     for (const [groupPrefix, group] of Object.entries(sliceNames)) {
-      const [pluralNames, singularNames] = partition(group, isPlural)
+      const [pluralNames, singularNames] = partition(
+        group.map((name) => [name, getMainSubject(name)] as const),
+        ([, mainSubject]) => isPlural(mainSubject),
+      )
+
+      /** Names that exist in both singular and plural forms for filtering later. */
+      const duplicates = {
+        singular: [] as Array<string>,
+        plural: [] as Array<string>,
+      }
 
       if (pluralNames.length > 0 && singularNames.length > 0) {
-        const message = 'Inconsistent pluralization of slice names'
+        for (const [singularName, mainSubject] of singularNames) {
+          const pluralized = singularName.replace(mainSubject, plural(mainSubject))
+          if (group.includes(pluralized)) {
+            duplicates.singular.push(singularName)
+            duplicates.plural.push(pluralized)
 
-        if (pluralNames.length >= singularNames.length) {
+            diagnostics.push({
+              message: `Avoid having both "${singularName}" and "${plural(singularName)}" entities${groupPrefix === '' ? '' : ' in the same slice group'}.`,
+              location: { path: join(entities.path, groupPrefix, singularName) },
+            })
+          }
+        }
+
+        const message = 'Inconsistent pluralization of entity names'
+        if (
+          pluralNames.length >= singularNames.length &&
+          singularNames.some(([name]) => !duplicates.singular.includes(name))
+        ) {
           diagnostics.push({
-            message: `${message}. Prefer all plural names`,
-            fixes: singularNames.map((name) => ({
-              type: 'rename',
-              path: join(entities.path, groupPrefix, name),
-              newName: plural(name),
-            })),
+            message: `${message}. Prefer all plural names.`,
+            fixes: singularNames
+              .filter(([name]) => !duplicates.singular.includes(name))
+              .map(([name, mainWord]) => ({
+                type: 'rename',
+                path: join(entities.path, groupPrefix, name),
+                newName: name.replace(mainWord, plural(mainWord)),
+              })),
             location: { path: join(entities.path, groupPrefix) },
           })
-        } else {
+        } else if (pluralNames.some(([name]) => !duplicates.plural.includes(name))) {
           diagnostics.push({
-            message: `${message}. Prefer all singular names`,
-            fixes: pluralNames.map((name) => ({
-              type: 'rename',
-              path: join(entities.path, groupPrefix, name),
-              newName: singular(name),
-            })),
+            message: `${message}. Prefer all singular names.`,
+            fixes: pluralNames
+              .filter(([name]) => !duplicates.plural.includes(name))
+              .map(([name, mainWord]) => ({
+                type: 'rename',
+                path: join(entities.path, groupPrefix, name),
+                newName: name.replace(mainWord, singular(mainWord)),
+              })),
             location: { path: join(entities.path, groupPrefix) },
           })
         }


### PR DESCRIPTION
Closes #8 

Extends the functionality of `inconsistent-naming` to support multi-word names and handle rename collisions