### PR TITLE
Separate Vitest-dependent utils into a different entrypoint

### DIFF
--- a/.changeset/curly-years-sparkle.md
+++ b/.changeset/curly-years-sparkle.md
@@ -1,5 +1,5 @@
 ---
-'@steiger/toolkit': patch
+'@steiger/toolkit': minor
 ---
 
 Separate Vitest-dependent utilities into a different entrypoint to make Vitest a truly optional peer dependency

--- a/.changeset/curly-years-sparkle.md
+++ b/.changeset/curly-years-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@steiger/toolkit': patch
+---
+
+Separate Vitest-dependent utilities into a different entrypoint to make Vitest a truly optional peer dependency

--- a/packages/steiger-plugin-fsd/src/_lib/collect-related-ts-configs.ts
+++ b/packages/steiger-plugin-fsd/src/_lib/collect-related-ts-configs.ts
@@ -1,6 +1,6 @@
 import { TSConfckParseResult } from 'tsconfck'
 import { dirname, resolve } from 'node:path'
-import { joinFromRoot } from '@steiger/toolkit'
+import { joinFromRoot } from '@steiger/toolkit/test'
 
 export type CollectRelatedTsConfigsPayload = {
   tsconfig: TSConfckParseResult['tsconfig']

--- a/packages/steiger-plugin-fsd/src/_lib/index-source-files.ts
+++ b/packages/steiger-plugin-fsd/src/_lib/index-source-files.ts
@@ -1,5 +1,6 @@
 import { getIndex, getLayers, getSegments, getSlices, isSliced, type LayerName } from '@feature-sliced/filesystem'
-import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot, type File, type Folder } from '@steiger/toolkit'
+import type { File, Folder } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 
 type SourceFile = {
   file: File

--- a/packages/steiger-plugin-fsd/src/ambiguous-slice-names/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/ambiguous-slice-names/index.spec.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path'
 import { expect, it } from 'vitest'
 
 import ambiguousSliceNames from './index.js'
-import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 
 it('reports no errors on a project without slice names that match some segment name in Shared', () => {
   const root = parseIntoFsdRoot(`

--- a/packages/steiger-plugin-fsd/src/excessive-slicing/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/excessive-slicing/index.spec.ts
@@ -1,6 +1,6 @@
 import { expect, it } from 'vitest'
 
-import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 import excessiveSlicing from './index.js'
 
 it('reports no errors on projects with moderate slicing', () => {

--- a/packages/steiger-plugin-fsd/src/forbidden-imports/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/forbidden-imports/index.spec.ts
@@ -1,6 +1,6 @@
 import { expect, it, vi } from 'vitest'
 
-import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 import forbiddenImports from './index.js'
 
 vi.mock('tsconfck', async (importOriginal) => {
@@ -23,7 +23,7 @@ vi.mock('tsconfck', async (importOriginal) => {
 
 vi.mock('node:fs', async (importOriginal) => {
   const originalFs = await importOriginal<typeof import('fs')>()
-  const { createFsMocks } = await import('@steiger/toolkit')
+  const { createFsMocks } = await import('@steiger/toolkit/test')
 
   return createFsMocks(
     {

--- a/packages/steiger-plugin-fsd/src/import-locality/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/import-locality/index.spec.ts
@@ -1,6 +1,6 @@
 import { expect, it, vi } from 'vitest'
 
-import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 import importLocality from './index.js'
 
 vi.mock('tsconfck', async (importOriginal) => {
@@ -12,7 +12,7 @@ vi.mock('tsconfck', async (importOriginal) => {
 
 vi.mock('node:fs', async (importOriginal) => {
   const originalFs = await importOriginal<typeof import('fs')>()
-  const { createFsMocks } = await import('@steiger/toolkit')
+  const { createFsMocks } = await import('@steiger/toolkit/test')
 
   return createFsMocks(
     {

--- a/packages/steiger-plugin-fsd/src/inconsistent-naming/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/inconsistent-naming/index.spec.ts
@@ -1,6 +1,6 @@
 import { expect, it } from 'vitest'
 
-import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 import inconsistentNaming from './index.js'
 
 it('reports no errors on slice names that are pluralized consistently', () => {

--- a/packages/steiger-plugin-fsd/src/insignificant-slice/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/insignificant-slice/index.spec.ts
@@ -1,7 +1,7 @@
 import { expect, it, vi } from 'vitest'
 import { join } from 'node:path'
 
-import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 import insignificantSlice from './index.js'
 
 vi.mock('tsconfck', async (importOriginal) => {
@@ -13,7 +13,7 @@ vi.mock('tsconfck', async (importOriginal) => {
 
 vi.mock('node:fs', async (importOriginal) => {
   const originalFs = await importOriginal<typeof import('fs')>()
-  const { createFsMocks } = await import('@steiger/toolkit')
+  const { createFsMocks } = await import('@steiger/toolkit/test')
 
   return createFsMocks(
     {

--- a/packages/steiger-plugin-fsd/src/no-file-segments/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-file-segments/index.spec.ts
@@ -1,6 +1,6 @@
 import { expect, it } from 'vitest'
 
-import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 import noFileSegments from './index.js'
 
 it('reports no errors on a project with only folder segments', async () => {

--- a/packages/steiger-plugin-fsd/src/no-layer-public-api/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-layer-public-api/index.spec.ts
@@ -1,7 +1,7 @@
 import { expect, it } from 'vitest'
 
 import noLayerPublicApi from './index.js'
-import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 
 it('reports no errors on a project without index files on layer level', () => {
   const root = parseIntoFsdRoot(`

--- a/packages/steiger-plugin-fsd/src/no-processes/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-processes/index.spec.ts
@@ -1,7 +1,7 @@
 import { expect, it } from 'vitest'
 
 import noProcesses from './index.js'
-import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 
 it('reports no errors on a project without the Processes layer', () => {
   const root = parseIntoFsdRoot(`

--- a/packages/steiger-plugin-fsd/src/no-public-api-sidestep/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-public-api-sidestep/index.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 import noPublicApiSidestep from './index.js'
 
 vi.mock('tsconfck', async (importOriginal) => {
@@ -12,7 +12,7 @@ vi.mock('tsconfck', async (importOriginal) => {
 
 vi.mock('node:fs', async (importOriginal) => {
   const originalFs = await importOriginal<typeof import('fs')>()
-  const { createFsMocks } = await import('@steiger/toolkit')
+  const { createFsMocks } = await import('@steiger/toolkit/test')
 
   return createFsMocks(
     {

--- a/packages/steiger-plugin-fsd/src/no-reserved-folder-names/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-reserved-folder-names/index.spec.ts
@@ -1,7 +1,7 @@
 import { expect, it } from 'vitest'
 
 import noReservedFolderNames from './index.js'
-import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 
 it('reports no errors on a project without subfolders in segments that use reserved names', () => {
   const root = parseIntoFsdRoot(`

--- a/packages/steiger-plugin-fsd/src/no-segmentless-slices/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-segmentless-slices/index.spec.ts
@@ -1,7 +1,7 @@
 import { expect, it } from 'vitest'
 
 import noSegmentlessSlices from './index.js'
-import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 
 it('reports no errors on a project where every slice has at least one segment', () => {
   const root = parseIntoFsdRoot(`

--- a/packages/steiger-plugin-fsd/src/no-segments-on-sliced-layers/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-segments-on-sliced-layers/index.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import noSegmentsOnSlicedLayers from './index.js'
-import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 
 describe('no-segments-on-sliced-layers rule', () => {
   it('reports no errors on a project where the sliced layers has no segments in direct children', () => {

--- a/packages/steiger-plugin-fsd/src/no-ui-in-app/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-ui-in-app/index.spec.ts
@@ -1,5 +1,5 @@
 import { expect, it } from 'vitest'
-import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 
 import noUiInApp from './index.js'
 

--- a/packages/steiger-plugin-fsd/src/public-api/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/public-api/index.spec.ts
@@ -1,7 +1,7 @@
 import { expect, it } from 'vitest'
 
 import publicApi from './index.js'
-import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 
 it('reports no errors on a project with all the required public APIs', () => {
   const root = parseIntoFsdRoot(`

--- a/packages/steiger-plugin-fsd/src/repetitive-naming/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/repetitive-naming/index.spec.ts
@@ -1,7 +1,7 @@
 import { expect, it } from 'vitest'
 
 import repetitiveNaming from './index.js'
-import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 
 it('reports no errors on a project with no repetitive words in slices', () => {
   const root = parseIntoFsdRoot(`

--- a/packages/steiger-plugin-fsd/src/segments-by-purpose/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/segments-by-purpose/index.spec.ts
@@ -1,7 +1,7 @@
 import { expect, it } from 'vitest'
 
 import segmentsByPurpose from './index.js'
-import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 
 it('reports no errors on a project with good segments', () => {
   const root = parseIntoFsdRoot(`

--- a/packages/steiger-plugin-fsd/src/shared-lib-grouping/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/shared-lib-grouping/index.spec.ts
@@ -1,6 +1,6 @@
 import { expect, it } from 'vitest'
 
-import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 import excessiveSlicing from './index.js'
 
 it('reports no errors on projects with no shared/lib', () => {

--- a/packages/steiger-plugin-fsd/src/typo-in-layer-name/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/typo-in-layer-name/index.spec.ts
@@ -1,5 +1,5 @@
 import { expect, it } from 'vitest'
-import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 
 import typoInLayerName from './index.js'
 

--- a/packages/steiger/src/features/calculate-diagnostic-severities/calculate-final-severity.spec.ts
+++ b/packages/steiger/src/features/calculate-diagnostic-severities/calculate-final-severity.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { joinFromRoot, parseIntoFolder } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder } from '@steiger/toolkit/test'
 
 import calculateFinalSeverities from './calculate-final-severity'
 import { GlobGroupWithSeverity } from '../../models/config'

--- a/packages/steiger/src/features/choose-root-folder/choose-from-guesses.ts
+++ b/packages/steiger/src/features/choose-root-folder/choose-from-guesses.ts
@@ -58,7 +58,7 @@ async function findRootFolderCandidates(): Promise<Array<string>> {
 if (import.meta.vitest) {
   const { describe, test, expect, vi, beforeEach } = import.meta.vitest
   const { vol } = await import('memfs')
-  const { joinFromRoot } = await import('@steiger/toolkit')
+  const { joinFromRoot } = await import('@steiger/toolkit/test')
 
   vi.mock('node:fs/promises', () => import('memfs').then((memfs) => memfs.fs.promises))
 

--- a/packages/steiger/src/features/choose-root-folder/choose-from-similar.ts
+++ b/packages/steiger/src/features/choose-root-folder/choose-from-similar.ts
@@ -99,7 +99,7 @@ async function resolveWithCorrections(path: string) {
 if (import.meta.vitest) {
   const { test, expect, vi } = import.meta.vitest
   const { vol } = await import('memfs')
-  const { joinFromRoot } = await import('@steiger/toolkit')
+  const { joinFromRoot } = await import('@steiger/toolkit/test')
 
   vi.mock('node:fs/promises', () => import('memfs').then((memfs) => memfs.fs.promises))
 

--- a/packages/steiger/src/features/remove-global-ignores-from-vfs/remove-global-ignores-from-vfs.spec.ts
+++ b/packages/steiger/src/features/remove-global-ignores-from-vfs/remove-global-ignores-from-vfs.spec.ts
@@ -1,5 +1,5 @@
 import { expect, it, describe } from 'vitest'
-import { joinFromRoot, parseIntoFolder } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder } from '@steiger/toolkit/test'
 
 import removeGlobalIgnoresFromVfs from './remove-global-ignores-from-vfs'
 

--- a/packages/steiger/src/features/run-rule/prepare-vfs-for-rule-run.spec.ts
+++ b/packages/steiger/src/features/run-rule/prepare-vfs-for-rule-run.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { joinFromRoot, parseIntoFolder } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder } from '@steiger/toolkit/test'
 
 import { prepareVfsForRuleRun } from './prepare-vfs-for-rule-run'
 import { GlobGroupWithSeverity } from '../../models/config'

--- a/packages/steiger/src/shared/globs/apply-exclusion.spec.ts
+++ b/packages/steiger/src/shared/globs/apply-exclusion.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { joinFromRoot, parseIntoFolder } from '@steiger/toolkit'
+import { joinFromRoot, parseIntoFolder } from '@steiger/toolkit/test'
 
 import { applyExclusion } from './apply-exclusion'
 import { not } from './not'

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -12,8 +12,14 @@
     "typecheck": "tsc --noEmit"
   },
   "exports": {
-    "types": "./dist/index.d.ts",
-    "import": "./dist/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./test": {
+      "types": "./dist/test.d.ts",
+      "import": "./dist/test.js"
+    }
   },
   "type": "module",
   "license": "MIT",

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -4,5 +4,3 @@ export { findAllRecursively } from './find-all-recursively.js'
 export { enableAllRules, createConfigs } from './create-configs.js'
 export { createPlugin } from './create-plugin.js'
 export type { ConfigObjectOf } from './config-object-of.js'
-
-export { compareMessages, createFsMocks, joinFromRoot, parseIntoFolder } from './prepare-test.js'

--- a/packages/toolkit/src/test.ts
+++ b/packages/toolkit/src/test.ts
@@ -1,0 +1,1 @@
+export { compareMessages, createFsMocks, joinFromRoot, parseIntoFolder } from './prepare-test.js'

--- a/packages/toolkit/tsup.config.ts
+++ b/packages/toolkit/tsup.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/test.ts'],
   format: ['esm'],
   dts: {
-    entry: 'src/index.ts',
+    entry: ['src/index.ts', 'src/test.ts'],
     resolve: true,
   },
   treeshake: true,


### PR DESCRIPTION
`@steiger/toolkit` has some utilities to help plugin writers write tests easier. We don't want to force people to use Vitest, so it's marked as an optional peer dependency. However, the file you import when you import `@steiger/toolkit` contains an import from `vitest`, which fails when you don't have Vitest installed.

This PR creates another entrypoint, `@steiger/toolkit/test`. Now this entrypoint has all the test utils, and you can only import it if you have Vitest installed. If you don't need test utils, you can import everything else from `@steiger/toolkit`, no Vitest required.