### PR TITLE
Support for Multiple Index Files

### DIFF
--- a/.changeset/grumpy-snails-relax.md
+++ b/.changeset/grumpy-snails-relax.md
@@ -1,0 +1,5 @@
+---
+'@feature-sliced/steiger-plugin': patch
+---
+
+Added support for multiple public APIs and enhanced logic for identifying public APIs

--- a/packages/steiger-plugin-fsd/package.json
+++ b/packages/steiger-plugin-fsd/package.json
@@ -34,7 +34,7 @@
     }
   ],
   "dependencies": {
-    "@feature-sliced/filesystem": "^2.4.0",
+    "@feature-sliced/filesystem": "^3.0.0",
     "fastest-levenshtein": "^1.0.16",
     "lodash-es": "^4.17.21",
     "pluralize": "^8.0.0",

--- a/packages/steiger-plugin-fsd/src/_lib/index-source-files.ts
+++ b/packages/steiger-plugin-fsd/src/_lib/index-source-files.ts
@@ -1,4 +1,4 @@
-import { getIndex, getLayers, getSegments, getSlices, isSliced, type LayerName } from '@feature-sliced/filesystem'
+import { getIndexes, getLayers, getSegments, getSlices, isSliced, type LayerName } from '@feature-sliced/filesystem'
 import type { File, Folder } from '@steiger/toolkit'
 import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
 
@@ -43,8 +43,9 @@ export function indexSourceFiles(root: Folder): Record<string, SourceFile> {
         for (const [segmentName, segment] of Object.entries(getSegments(slice))) {
           walk(segment, { layerName: layerName as LayerName, sliceName, segmentName })
         }
-        const index = getIndex(slice)
-        if (index !== undefined) {
+        const indexes = getIndexes(slice)
+
+        for (const index of indexes) {
           walk(index, { layerName: layerName as LayerName, sliceName, segmentName: null })
         }
       }

--- a/packages/steiger-plugin-fsd/src/no-layer-public-api/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-layer-public-api/index.spec.ts
@@ -54,3 +54,64 @@ it('reports errors on a project with index files on layer level', () => {
     { message: 'Layer "pages" should not have an index file', location: { path: joinFromRoot('pages', 'index.ts') } },
   ])
 })
+
+it('reports errors on a project with multiple index files on layer level', () => {
+  const root = parseIntoFsdRoot(`
+    📂 shared
+      📂 ui
+        📄 index.ts
+        📄 index.js
+      📄 index.js
+    📂 entities
+      📂 user
+        📂 ui
+        📄 index.js
+    📂 pages
+      📂 home
+        📂 ui
+        📄 index.js
+      📂 editor
+        📂 ui
+        📄 index.ts
+        📄 index.js
+      📄 index.client.js
+      📄 index.server.js
+  `)
+
+  const diagnostics = noLayerPublicApi.check(root).diagnostics
+  expect(diagnostics).toEqual([
+    { message: 'Layer "shared" should not have an index file', location: { path: joinFromRoot('shared', 'index.js') } },
+    {
+      message: 'Layer "pages" should not have an index file',
+      location: { path: joinFromRoot('pages', 'index.client.js') },
+    },
+    {
+      message: 'Layer "pages" should not have an index file',
+      location: { path: joinFromRoot('pages', 'index.server.js') },
+    },
+  ])
+})
+
+it('reports no errors on a project with multiple index files in valid locations', () => {
+  const root = parseIntoFsdRoot(`
+    📂 shared
+      📂 ui
+        📄 index.js
+      📂 lib
+        📄 index.js
+    📂 entities
+      📂 user
+        📂 ui
+        📄 index.js
+    📂 pages
+      📂 home
+        📂 ui
+        📄 index.client.js
+        📄 index.server.js
+      📂 editor
+        📂 ui
+        📄 index.js
+  `)
+
+  expect(noLayerPublicApi.check(root)).toEqual({ diagnostics: [] })
+})

--- a/packages/steiger-plugin-fsd/src/no-layer-public-api/index.ts
+++ b/packages/steiger-plugin-fsd/src/no-layer-public-api/index.ts
@@ -1,4 +1,4 @@
-import { getIndex, getLayers } from '@feature-sliced/filesystem'
+import { getIndexes, getLayers } from '@feature-sliced/filesystem'
 import type { PartialDiagnostic, Rule } from '@steiger/toolkit'
 import { NAMESPACE } from '../constants.js'
 
@@ -12,14 +12,16 @@ const noLayerPublicApi = {
     const diagnostics: Array<PartialDiagnostic> = []
 
     for (const [layerName, layer] of Object.entries(getLayers(root))) {
-      const index = getIndex(layer)
+      const indexes = getIndexes(layer)
       const notAmongExceptions = !exceptionLayers.includes(layerName)
 
-      if (notAmongExceptions && index !== undefined) {
-        diagnostics.push({
-          message: `Layer "${layerName}" should not have an index file`,
-          location: { path: index.path },
-        })
+      if (notAmongExceptions) {
+        for (const index of indexes) {
+          diagnostics.push({
+            message: `Layer "${layerName}" should not have an index file`,
+            location: { path: index.path },
+          })
+        }
       }
     }
 

--- a/packages/steiger-plugin-fsd/src/no-public-api-sidestep/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-public-api-sidestep/index.spec.ts
@@ -22,6 +22,8 @@ vi.mock('node:fs', async (importOriginal) => {
       '/shared/ui/Button.tsx': 'import styles from "./styles";',
       '/shared/ui/TextField.tsx': 'import styles from "./styles";',
       '/shared/ui/index.ts': '',
+      '/shared/ui/index.server.js': 'export const serverUtil = () => {};',
+      '/shared/ui/index.client.js': 'export const clientUtil = () => {};',
       '/shared/lib/index.ts': '',
       '/shared/lib/dates.ts': '',
       '/shared/lib/i18n/index.ts': '',
@@ -45,6 +47,13 @@ vi.mock('node:fs', async (importOriginal) => {
       '/pages/settings/ui/SettingsPage.tsx':
         'import { Button } from "@/shared/ui"; import { dates } from "@/shared/lib/dates"; import { translator } from "@/shared/lib/i18n"',
       '/pages/settings/ui/Password.tsx': 'import { translator } from "@/shared/lib/i18n/translator";',
+      '/pages/home/ui/HomePage.tsx': `
+        import { serverUtil } from "@/shared/ui/index.server.js";
+        import { clientUtil } from "@/shared/ui/index.client.js";
+        serverUtil();
+        clientUtil();
+      `,
+      '/pages/home/index.ts': '',
     },
     originalFs,
   )
@@ -133,6 +142,22 @@ it('reports errors on a project with a public API sidestep on shared', async () 
       location: { path: joinFromRoot('pages', 'editor', 'ui', 'SubmitButton.tsx') },
     },
   ])
+})
+
+it('reports no errors when importing from multiple public APIs', async () => {
+  const root = parseIntoFsdRoot(`
+    📂 shared
+      📂 ui
+        📄 index.server.js
+        📄 index.client.js
+    📂 pages
+      📂 home
+        📂 ui
+          📄 HomePage.tsx
+        📄 index.ts
+  `)
+
+  expect((await noPublicApiSidestep.check(root)).diagnostics).toEqual([])
 })
 
 describe('specifics of shared/lib and shared/ui', () => {

--- a/packages/steiger-plugin-fsd/src/public-api/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/public-api/index.spec.ts
@@ -147,3 +147,15 @@ it('reports errors on top-level folders in shared/lib and shared/ui that are mis
     },
   ])
 })
+
+it('reports no errors on a SSR project with server-side public APIs', () => {
+  const root = parseIntoFsdRoot(`
+    📂 pages
+      📂 pageA
+        📄 index.server.js
+      📂 pageB
+        📄 index.server.js
+  `)
+
+  expect(publicApi.check(root)).toEqual({ diagnostics: [] })
+})

--- a/packages/steiger-plugin-fsd/src/public-api/index.ts
+++ b/packages/steiger-plugin-fsd/src/public-api/index.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path'
-import { getLayers, getSegments, isSliced, getIndex, getSlices } from '@feature-sliced/filesystem'
+import { getLayers, getSegments, isSliced, getIndexes, getSlices } from '@feature-sliced/filesystem'
 import type { PartialDiagnostic, Rule } from '@steiger/toolkit'
 import { NAMESPACE } from '../constants.js'
 
@@ -16,7 +16,7 @@ const publicApi = {
           continue
         }
         for (const [segmentName, segment] of Object.entries(getSegments(layer))) {
-          if (getIndex(segment) === undefined) {
+          if (getIndexes(segment).length === 0) {
             if (!['ui', 'lib'].includes(segmentName)) {
               diagnostics.push({
                 message: 'This segment is missing a public API.',
@@ -32,7 +32,7 @@ const publicApi = {
               })
             } else if (segment.type === 'folder') {
               for (const child of segment.children) {
-                if (child.type === 'folder' && getIndex(child) === undefined) {
+                if (child.type === 'folder' && getIndexes(child).length === 0) {
                   diagnostics.push({
                     message: `This top-level folder in shared/${segmentName} is missing a public API.`,
                     fixes: [
@@ -51,7 +51,7 @@ const publicApi = {
         }
       } else {
         for (const slice of Object.values(getSlices(layer))) {
-          if (getIndex(slice) === undefined) {
+          if (getIndexes(slice).length === 0) {
             diagnostics.push({
               message: 'This slice is missing a public API.',
               fixes: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,8 +213,8 @@ importers:
   packages/steiger-plugin-fsd:
     dependencies:
       '@feature-sliced/filesystem':
-        specifier: ^2.4.0
-        version: 2.4.0
+        specifier: ^3.0.0
+        version: 3.0.0
       fastest-levenshtein:
         specifier: ^1.0.16
         version: 1.0.16
@@ -308,7 +308,7 @@ importers:
         version: 15.14.0
       typescript-eslint:
         specifier: ^8.20.0
-        version: 8.20.0(eslint@9.18.0)(typescript@5.7.3)
+        version: 8.20.0(eslint@9.18.0)(typescript@5.8.2)
     devDependencies:
       eslint-config-prettier:
         specifier: ^10.0.1
@@ -740,8 +740,8 @@ packages:
     resolution: {integrity: sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@feature-sliced/filesystem@2.4.0':
-    resolution: {integrity: sha512-aOFdPACNvkFXYb+gNHId8UCRD5fm7Z9/RV6JgBPlgEvm1QtLS4idg2XeHMDGnHrNRCS4ki+0RauxVZxm+g9pvw==}
+  '@feature-sliced/filesystem@3.0.0':
+    resolution: {integrity: sha512-gg+wkH9GOj9qLS2U2eFoamVc1wSf2Zdc5QtO4ZDlnH4CW2Dus0THP4xwoDtxnOspavZpYJc1DHMkI+pcoNoNgQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2562,6 +2562,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
@@ -3090,9 +3095,9 @@ snapshots:
       '@eslint/core': 0.10.0
       levn: 0.4.1
 
-  '@feature-sliced/filesystem@2.4.0':
+  '@feature-sliced/filesystem@3.0.0':
     dependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   '@humanfs/core@0.19.1': {}
 
@@ -3399,32 +3404,32 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.20.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.20.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.8.2))(eslint@9.18.0)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.20.0(eslint@9.18.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.20.0(eslint@9.18.0)(typescript@5.8.2)
       '@typescript-eslint/scope-manager': 8.20.0
-      '@typescript-eslint/type-utils': 8.20.0(eslint@9.18.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.20.0(eslint@9.18.0)(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.20.0
       eslint: 9.18.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 2.0.0(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.0(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.20.0
       '@typescript-eslint/types': 8.20.0
-      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.20.0
       debug: 4.4.0
       eslint: 9.18.0
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -3433,14 +3438,14 @@ snapshots:
       '@typescript-eslint/types': 8.20.0
       '@typescript-eslint/visitor-keys': 8.20.0
 
-  '@typescript-eslint/type-utils@8.20.0(eslint@9.18.0)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.20.0(eslint@9.18.0)(typescript@5.8.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.8.2)
       debug: 4.4.0
       eslint: 9.18.0
-      ts-api-utils: 2.0.0(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.0(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -3463,7 +3468,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.20.0(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.20.0(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/types': 8.20.0
       '@typescript-eslint/visitor-keys': 8.20.0
@@ -3472,19 +3477,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 2.0.0(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.0(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.20.0(eslint@9.18.0)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.20.0(eslint@9.18.0)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.18.0)
       '@typescript-eslint/scope-manager': 8.20.0
       '@typescript-eslint/types': 8.20.0
-      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.8.2)
       eslint: 9.18.0
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4854,9 +4859,9 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
-  ts-api-utils@2.0.0(typescript@5.7.3):
+  ts-api-utils@2.0.0(typescript@5.8.2):
     dependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   ts-interface-checker@0.1.13: {}
 
@@ -4934,13 +4939,13 @@ snapshots:
 
   type-fest@1.4.0: {}
 
-  typescript-eslint@8.20.0(eslint@9.18.0)(typescript@5.7.3):
+  typescript-eslint@8.20.0(eslint@9.18.0)(typescript@5.8.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.20.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.20.0(eslint@9.18.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.20.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.8.2))(eslint@9.18.0)(typescript@5.8.2)
+      '@typescript-eslint/parser': 8.20.0(eslint@9.18.0)(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.8.2)
       eslint: 9.18.0
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4948,6 +4953,8 @@ snapshots:
     optional: true
 
   typescript@5.7.3: {}
+
+  typescript@5.8.2: {}
 
   undici-types@5.26.5: {}
 


### PR DESCRIPTION
### Description
This PR allows support for multiple index files. 

Also, index files other than `index.js` are supported such as `index.client.js` and `index.server.js`.

To enable these improvements, the `@steiger/filesystem` package has been upgraded to `v3.0.0`. As part of this update, the `getIndex` function has been replaced with the new `getIndexes` function.

### Fixes
Fixes #180 