### PR TITLE
Split `forbidden imports` Into Seperate Rules

### DIFF
--- a/.changeset/purple-snakes-fetch.md
+++ b/.changeset/purple-snakes-fetch.md
@@ -1,0 +1,5 @@
+---
+'@feature-sliced/steiger-plugin': patch
+---
+
+Split `forbidden-imports` rule into granular `no-higher-level-imports` and `no-cross-imports` rules for better flexibility

--- a/.changeset/slow-kangaroos-talk.md
+++ b/.changeset/slow-kangaroos-talk.md
@@ -1,0 +1,5 @@
+---
+'@steiger/toolkit': patch
+---
+
+Add `enableSpecificRules` function for backward compatibility and selective rule adoption

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Currently, Steiger is not extendable with more rules, though that will change in
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/ambiguous-slice-names/README.md"><code>fsd/ambiguous-slice-names</code></a></td> <td>Forbid slice names that that match some segment’s name in the Shared layer.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/excessive-slicing/README.md"><code>fsd/excessive-slicing</code></a></td> <td>Forbid having too many ungrouped slices or too many slices in a group.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/forbidden-imports/README.md"><code>fsd/forbidden-imports</code></a></td> <td>Forbid imports from higher layers and cross-imports between slices on the same layer.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-cross-imports/README.md"><code>fsd/no-cross-imports</code></a></td> <td>Forbid cross-imports between slices on the same layer.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-higher-level-imports/README.md"><code>fsd/no-higher-level-imports</code></a></td> <td>Forbid imports from higher layers.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/inconsistent-naming/README.md"><code>fsd/inconsistent-naming</code></a></td> <td>Ensure that all entities are named consistently in terms of pluralization.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/insignificant-slice/README.md"><code>fsd/insignificant-slice</code></a></td> <td>Detect slices that have just one reference or no references to them at all.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-layer-public-api/README.md"><code>fsd/no-layer-public-api</code></a></td> <td>Forbid index files on the layer level.</td> </tr>

--- a/packages/steiger-plugin-fsd/src/forbidden-imports/README.md
+++ b/packages/steiger-plugin-fsd/src/forbidden-imports/README.md
@@ -198,14 +198,3 @@ flowchart BT
   pages/editor/ui/EditorPage.tsx --> shared/ui/index.ts
   pages/editor/ui/EditorPage.tsx --> pages/editor/ui/Editor.tsx
 ```
-
-## Rationale
-
-This is one of the main rules of Feature-Sliced Design, it ensures low coupling and predictability in refactoring.
-
-If you need more granular control, this rule's functionality is split into two separate rules that you can use independently:
-
-- `no-higher-level-imports`: Only checks for imports from higher layers (e.g., features importing from pages)
-- `no-cross-imports`: Only checks for cross-imports between slices on the same layer (e.g., one entity importing from another entity)
-
-Using these separate rules allows you to enforce only specific aspects of the import restrictions or configure them differently.

--- a/packages/steiger-plugin-fsd/src/forbidden-imports/README.md
+++ b/packages/steiger-plugin-fsd/src/forbidden-imports/README.md
@@ -198,3 +198,7 @@ flowchart BT
   pages/editor/ui/EditorPage.tsx --> shared/ui/index.ts
   pages/editor/ui/EditorPage.tsx --> pages/editor/ui/Editor.tsx
 ```
+
+## Rationale
+
+This is one of the main rules of Feature-Sliced Design, it ensures low coupling and predictability in refactoring.

--- a/packages/steiger-plugin-fsd/src/forbidden-imports/README.md
+++ b/packages/steiger-plugin-fsd/src/forbidden-imports/README.md
@@ -6,6 +6,36 @@ This rule forbids imports from higher layers and cross-imports between slices on
 >
 > https://feature-sliced.design/docs/reference/layers#import-rule-on-layers
 
+> [!NOTE]
+> If you need more granular control, this rule's functionality is split into two separate rules that you can use independently:
+>
+> - `no-higher-level-imports`: Only checks for imports from higher layers (e.g., features importing from pages)
+> - `no-cross-imports`: Only checks for cross-imports between slices on the same layer (e.g., one entity importing from another entity)
+>
+> ```javascript
+> // steiger.config.js
+> import { defineConfig } from 'steiger'
+> import fsd from '@feature-sliced/steiger-plugin'
+>
+> export default defineConfig([
+>   ...fsd.configs.recommended,
+>   {
+>     rules: {
+>       'fsd/forbidden-imports': 'off',
+>       'fsd/no-cross-imports': 'error',
+>       'fsd/no-higher-level-imports': 'error',
+>     },
+>   },
+>   {
+>     // Allow cross-imports between widgets, for example
+>     files: ['src/widgets/**'],
+>     rules: {
+>       'fsd/no-cross-imports': 'off',
+>     },
+>   },
+> ])
+> ```
+
 Example of a project structure that passes this rule (arrows signify imports):
 
 ```mermaid
@@ -172,8 +202,6 @@ flowchart BT
 ## Rationale
 
 This is one of the main rules of Feature-Sliced Design, it ensures low coupling and predictability in refactoring.
-
-## Related Rules
 
 If you need more granular control, this rule's functionality is split into two separate rules that you can use independently:
 

--- a/packages/steiger-plugin-fsd/src/forbidden-imports/README.md
+++ b/packages/steiger-plugin-fsd/src/forbidden-imports/README.md
@@ -172,3 +172,12 @@ flowchart BT
 ## Rationale
 
 This is one of the main rules of Feature-Sliced Design, it ensures low coupling and predictability in refactoring.
+
+## Related Rules
+
+If you need more granular control, this rule's functionality is split into two separate rules that you can use independently:
+
+- `no-higher-level-imports`: Only checks for imports from higher layers (e.g., features importing from pages)
+- `no-cross-imports`: Only checks for cross-imports between slices on the same layer (e.g., one entity importing from another entity)
+
+Using these separate rules allows you to enforce only specific aspects of the import restrictions or configure them differently.

--- a/packages/steiger-plugin-fsd/src/index.ts
+++ b/packages/steiger-plugin-fsd/src/index.ts
@@ -39,9 +39,9 @@ const enabledRules = [
   typoInLayerName,
   noProcesses,
 ]
-const disabeldRules = [noCrossImports, noHigherLevelImports]
+const disabledRules = [noCrossImports, noHigherLevelImports]
 
-const rules = [...enabledRules, ...disabeldRules]
+const rules = [...enabledRules, ...disabledRules]
 
 const plugin = createPlugin({
   meta: {

--- a/packages/steiger-plugin-fsd/src/index.ts
+++ b/packages/steiger-plugin-fsd/src/index.ts
@@ -1,5 +1,4 @@
-import { enableAllRules, type ConfigObjectOf, createPlugin, createConfigs } from '@steiger/toolkit'
-
+import { enableSpecificRules, type ConfigObjectOf, createPlugin, createConfigs } from '@steiger/toolkit'
 import ambiguousSliceNames from './ambiguous-slice-names/index.js'
 import excessiveSlicing from './excessive-slicing/index.js'
 import forbiddenImports from './forbidden-imports/index.js'
@@ -18,8 +17,10 @@ import sharedLibGrouping from './shared-lib-grouping/index.js'
 import typoInLayerName from './typo-in-layer-name/index.js'
 import noProcesses from './no-processes/index.js'
 import packageJson from '../package.json' with { type: 'json' }
+import noCrossImports from './no-cross-imports/index.js'
+import noHigherLevelImports from './no-higher-level-imports/index.js'
 
-const rules = [
+const enabledRules = [
   ambiguousSliceNames,
   excessiveSlicing,
   forbiddenImports,
@@ -38,6 +39,9 @@ const rules = [
   typoInLayerName,
   noProcesses,
 ]
+const disabeldRules = [noCrossImports, noHigherLevelImports]
+
+const rules = [...enabledRules, ...disabeldRules]
 
 const plugin = createPlugin({
   meta: {
@@ -48,7 +52,7 @@ const plugin = createPlugin({
 })
 
 const configs = createConfigs({
-  recommended: enableAllRules(plugin),
+  recommended: enableSpecificRules(plugin, enabledRules),
 })
 
 export default {

--- a/packages/steiger-plugin-fsd/src/no-cross-imports/README.md
+++ b/packages/steiger-plugin-fsd/src/no-cross-imports/README.md
@@ -1,6 +1,6 @@
 # `no-cross-imports`
 
-This rule forbids cross-imports between slices on the same layer. This is in accordance to the slice isolation principle in Feature-Sliced Design:
+This rule forbids cross-imports between slices on the same layer. This is in accordance to the import rule on layers:
 
 > A module in a slice can only import other slices when they are located on layers strictly below.
 >
@@ -39,8 +39,8 @@ flowchart BT
 flowchart BT
   subgraph entities
     subgraph entities/user[user]
-      subgraph entities/user/@x[@x]
-        entities/user/@x/product.ts[product.ts]
+      subgraph entities/user/at-x[@x]
+        entities/user/at-x/product.ts[product.ts]
       end
       subgraph entities/user/ui[ui]
         entities/user/ui/UserAvatar.tsx[UserAvatar.tsx]
@@ -56,7 +56,7 @@ flowchart BT
   end
 
   entities/user/ui/UserAvatar.tsx --> shared/ui/index.ts
-  entities/product/ui/ProductCard.tsx --> entities/user/@x/product.ts
+  entities/product/ui/ProductCard.tsx --> entities/user/at-x/product.ts
 ```
 
 Examples of project structures that fail this rule:

--- a/packages/steiger-plugin-fsd/src/no-cross-imports/README.md
+++ b/packages/steiger-plugin-fsd/src/no-cross-imports/README.md
@@ -1,0 +1,108 @@
+# `no-cross-imports`
+
+This rule forbids cross-imports between slices on the same layer. This is in accordance to the slice isolation principle in Feature-Sliced Design:
+
+> A module in a slice can only import other slices when they are located on layers strictly below.
+>
+> https://feature-sliced.design/docs/reference/layers#import-rule-on-layers
+
+Example of a project structure that passes this rule (arrows signify imports):
+
+```mermaid
+flowchart BT
+  subgraph entities
+    subgraph entities/user[user]
+      subgraph entities/user/ui[ui]
+        entities/user/ui/UserAvatar.tsx[UserAvatar.tsx]
+      end
+      entities/user/index.ts[index.ts]
+    end
+    subgraph entities/product[product]
+      subgraph entities/product/ui[ui]
+        entities/product/ui/ProductCard.tsx[ProductCard.tsx]
+      end
+      entities/product/index.ts[index.ts]
+    end
+  end
+
+  subgraph shared
+    subgraph shared/ui[ui]
+      shared/ui/index.ts[index.ts]
+    end
+  end
+
+  entities/user/ui/UserAvatar.tsx --> shared/ui/index.ts
+  entities/product/ui/ProductCard.tsx --> shared/ui/index.ts
+```
+
+```mermaid
+flowchart BT
+  subgraph entities
+    subgraph entities/user[user]
+      subgraph entities/user/@x[@x]
+        entities/user/@x/product.ts[product.ts]
+      end
+      subgraph entities/user/ui[ui]
+        entities/user/ui/UserAvatar.tsx[UserAvatar.tsx]
+      end
+      entities/user/index.ts[index.ts]
+    end
+    subgraph entities/product[product]
+      subgraph entities/product/ui[ui]
+        entities/product/ui/ProductCard.tsx[ProductCard.tsx]
+      end
+      entities/product/index.ts[index.ts]
+    end
+  end
+
+  entities/user/ui/UserAvatar.tsx --> shared/ui/index.ts
+  entities/product/ui/ProductCard.tsx --> entities/user/@x/product.ts
+```
+
+Examples of project structures that fail this rule:
+
+```mermaid
+flowchart BT
+  subgraph entities
+    subgraph entities/user[user]
+      subgraph entities/user/ui[ui]
+        entities/user/ui/UserAvatar.tsx[UserAvatar.tsx]
+      end
+      entities/user/index.ts[index.ts]
+    end
+    subgraph entities/product[product]
+      subgraph entities/product/ui[ui]
+        entities/product/ui/ProductCard.tsx[ProductCard.tsx]
+      end
+      entities/product/index.ts[index.ts]
+    end
+  end
+
+  entities/user/ui/UserAvatar.tsx --> shared/ui/index.ts
+  entities/product/ui/ProductCard.tsx --❌--> entities/user/index.ts
+```
+
+```mermaid
+flowchart BT
+  subgraph features
+    subgraph features/auth[auth]
+      subgraph features/auth/ui[ui]
+        features/auth/ui/LoginForm.tsx[LoginForm.tsx]
+      end
+      features/auth/index.ts[index.ts]
+    end
+    subgraph features/registration[registration]
+      subgraph features/registration/ui[ui]
+        features/registration/ui/RegistrationForm.tsx[RegistrationForm.tsx]
+      end
+      features/registration/index.ts[index.ts]
+    end
+  end
+
+  features/auth/ui/LoginForm.tsx --> shared/ui/index.ts
+  features/registration/ui/RegistrationForm.tsx --❌--> features/auth/ui/LoginForm.tsx
+```
+
+## Rationale
+
+This is one of the main rules of Feature-Sliced Design, it ensures low coupling and predictability in refactoring.

--- a/packages/steiger-plugin-fsd/src/no-cross-imports/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-cross-imports/index.spec.ts
@@ -1,0 +1,191 @@
+import { expect, it, vi } from 'vitest'
+
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
+import forbiddenImports from './index.js'
+
+vi.mock('tsconfck', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('tsconfck')>()),
+    parse: vi.fn(() =>
+      Promise.resolve({
+        tsconfig: {
+          compilerOptions: {
+            baseUrl: '/src/',
+            paths: {
+              '@/*': ['./*'],
+            },
+          },
+        },
+      }),
+    ),
+  }
+})
+
+vi.mock('node:fs', async (importOriginal) => {
+  const originalFs = await importOriginal<typeof import('fs')>()
+  const { createFsMocks } = await import('@steiger/toolkit/test')
+
+  return createFsMocks(
+    {
+      '/src/shared/ui/styles.ts': '',
+      '/src/shared/ui/Button.tsx': 'import styles from "./styles";',
+      '/src/shared/ui/TextField.tsx': 'import styles from "./styles";',
+      '/src/shared/ui/index.ts': '',
+      '/src/entities/user/ui/UserAvatar.tsx': 'import { Button } from "@/shared/ui"',
+      '/src/entities/user/index.ts': '',
+      '/src/entities/user/@x/product.ts': '',
+      '/src/entities/product/ui/ProductCard.tsx': 'import { UserAvatar } from "@/entities/user"',
+      '/src/entities/product/ui/GoodProductCard.tsx': 'import { UserAvatar } from "@/entities/user/@x/product"',
+      '/src/entities/product/index.ts': '',
+      '/src/entities/cart/ui/SmallCart.tsx': 'import { App } from "@/app"',
+      '/src/entities/cart/ui/BadSmallCart.tsx': 'import { UserAvatar } from "@/entities/user/@x/product"',
+      '/src/entities/cart/lib/count-cart-items.ts': 'import root from "@/app/root.ts"',
+      '/src/entities/cart/lib/index.ts': '',
+      '/src/entities/cart/index.ts': '',
+      '/src/features/comments/ui/CommentCard.tsx': 'import { styles } from "@/pages/editor"',
+      '/src/features/comments/index.ts': '',
+      '/src/pages/editor/ui/styles.ts': '',
+      '/src/pages/editor/ui/EditorPage.tsx': 'import { Button } from "@/shared/ui"; import { Editor } from "./Editor"',
+      '/src/pages/editor/ui/Editor.tsx': 'import { TextField } from "@/shared/ui"',
+      '/src/pages/editor/index.ts': '',
+      '/src/app': '',
+      '/src/app/ui/index.ts': '',
+      '/src/app/index.ts': '',
+      '/src/app/root.ts': '',
+    },
+    originalFs,
+  )
+})
+
+it('reports no errors on a project with only correct imports', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 shared
+        📂 ui
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 pages
+        📂 editor
+          📂 ui
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await forbiddenImports.check(root)).diagnostics).toEqual([])
+})
+
+it('reports errors on a project with cross-imports in entities', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 shared
+        📂 ui
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 user
+          📂 ui
+            📄 UserAvatar.tsx
+          📄 index.ts
+        📂 product
+          📂 ui
+            📄 ProductCard.tsx
+          📄 index.ts
+      📂 pages
+        📂 editor
+          📂 ui
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await forbiddenImports.check(root)).diagnostics).toEqual([
+    {
+      message: `Forbidden cross-import from slice "user".`,
+      location: { path: joinFromRoot('src', 'entities', 'product', 'ui', 'ProductCard.tsx') },
+    },
+  ])
+})
+
+it('reports no errors on a project with cross-imports through @x', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 shared
+        📂 ui
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 user
+          📂 @x
+            📄 product.ts
+          📂 ui
+            📄 UserAvatar.tsx
+          📄 index.ts
+        📂 product
+          📂 ui
+            📄 GoodProductCard.tsx
+          📄 index.ts
+      📂 pages
+        📂 editor
+          📂 ui
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await forbiddenImports.check(root)).diagnostics).toEqual([])
+})
+
+it('reports errors on a project with incorrect cross-imports through @x', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 shared
+        📂 ui
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 user
+          📂 @x
+            📄 product.ts
+          📂 ui
+            📄 UserAvatar.tsx
+          📄 index.ts
+        📂 product
+          📂 ui
+            📄 GoodProductCard.tsx
+          📄 index.ts
+        📂 cart
+          📂 ui
+            📄 BadSmallCart.tsx
+          📄 index.ts
+      📂 pages
+        📂 editor
+          📂 ui
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await forbiddenImports.check(root)).diagnostics).toEqual([
+    {
+      message: `Forbidden cross-import from slice "user".`,
+      location: { path: joinFromRoot('src', 'entities', 'cart', 'ui', 'BadSmallCart.tsx') },
+    },
+  ])
+})

--- a/packages/steiger-plugin-fsd/src/no-cross-imports/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-cross-imports/index.spec.ts
@@ -1,7 +1,7 @@
 import { expect, it, vi } from 'vitest'
 
 import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
-import forbiddenImports from './index.js'
+import noCrossImports from './index.js'
 
 vi.mock('tsconfck', async (importOriginal) => {
   return {
@@ -76,7 +76,7 @@ it('reports no errors on a project with only correct imports', async () => {
     joinFromRoot('src'),
   )
 
-  expect((await forbiddenImports.check(root)).diagnostics).toEqual([])
+  expect((await noCrossImports.check(root)).diagnostics).toEqual([])
 })
 
 it('reports errors on a project with cross-imports in entities', async () => {
@@ -107,7 +107,7 @@ it('reports errors on a project with cross-imports in entities', async () => {
     joinFromRoot('src'),
   )
 
-  expect((await forbiddenImports.check(root)).diagnostics).toEqual([
+  expect((await noCrossImports.check(root)).diagnostics).toEqual([
     {
       message: `Forbidden cross-import from slice "user".`,
       location: { path: joinFromRoot('src', 'entities', 'product', 'ui', 'ProductCard.tsx') },
@@ -145,7 +145,7 @@ it('reports no errors on a project with cross-imports through @x', async () => {
     joinFromRoot('src'),
   )
 
-  expect((await forbiddenImports.check(root)).diagnostics).toEqual([])
+  expect((await noCrossImports.check(root)).diagnostics).toEqual([])
 })
 
 it('reports errors on a project with incorrect cross-imports through @x', async () => {
@@ -182,7 +182,7 @@ it('reports errors on a project with incorrect cross-imports through @x', async 
     joinFromRoot('src'),
   )
 
-  expect((await forbiddenImports.check(root)).diagnostics).toEqual([
+  expect((await noCrossImports.check(root)).diagnostics).toEqual([
     {
       message: `Forbidden cross-import from slice "user".`,
       location: { path: joinFromRoot('src', 'entities', 'cart', 'ui', 'BadSmallCart.tsx') },

--- a/packages/steiger-plugin-fsd/src/no-cross-imports/index.ts
+++ b/packages/steiger-plugin-fsd/src/no-cross-imports/index.ts
@@ -1,0 +1,68 @@
+import * as fs from 'node:fs'
+import { join } from 'node:path'
+import { isCrossImportPublicApi } from '@feature-sliced/filesystem'
+import precinct from 'precinct'
+const { paperwork } = precinct
+import { parse as parseNearestTsConfig } from 'tsconfck'
+import type { PartialDiagnostic, Rule } from '@steiger/toolkit'
+
+import { indexSourceFiles } from '../_lib/index-source-files.js'
+import { collectRelatedTsConfigs } from '../_lib/collect-related-ts-configs.js'
+import { resolveDependency } from '../_lib/resolve-dependency.js'
+import { NAMESPACE } from '../constants.js'
+
+const noCrossImports = {
+  name: `${NAMESPACE}/no-cross-imports` as const,
+  async check(root) {
+    const diagnostics: Array<PartialDiagnostic> = []
+    const parseResult = await parseNearestTsConfig(root.children[0]?.path ?? root.path)
+    const tsConfigs = collectRelatedTsConfigs(parseResult)
+    const sourceFileIndex = indexSourceFiles(root)
+
+    for (const sourceFile of Object.values(sourceFileIndex)) {
+      const dependencies = paperwork(sourceFile.file.path, { includeCore: false, fileSystem: fs })
+      for (const dependency of dependencies) {
+        const resolvedDependency = resolveDependency(
+          dependency,
+          sourceFile.file.path,
+          tsConfigs,
+          fs.existsSync,
+          fs.existsSync,
+        )
+
+        if (resolvedDependency === null) {
+          continue
+        }
+
+        const dependencyLocation = sourceFileIndex[resolvedDependency]
+        if (dependencyLocation === undefined) {
+          continue
+        }
+
+        if (
+          sourceFile.layerName === dependencyLocation.layerName &&
+          sourceFile.sliceName !== dependencyLocation.sliceName
+        ) {
+          if (
+            dependencyLocation.sliceName !== null &&
+            sourceFile.sliceName !== null &&
+            !isCrossImportPublicApi(dependencyLocation.file, {
+              inSlice: dependencyLocation.sliceName,
+              forSlice: sourceFile.sliceName,
+              layerPath: join(root.path, dependencyLocation.layerName),
+            })
+          ) {
+            diagnostics.push({
+              message: `Forbidden cross-import from slice "${dependencyLocation.sliceName}".`,
+              location: { path: sourceFile.file.path },
+            })
+          }
+        }
+      }
+    }
+
+    return { diagnostics }
+  },
+} satisfies Rule
+
+export default noCrossImports

--- a/packages/steiger-plugin-fsd/src/no-higher-level-imports/README.md
+++ b/packages/steiger-plugin-fsd/src/no-higher-level-imports/README.md
@@ -1,0 +1,132 @@
+# `no-higher-level-imports`
+
+This rule forbids imports from higher layers in the Feature-Sliced Design architecture. This is in accordance to the import rule on layers:
+
+> A module in a slice can only import other slices when they are located on layers strictly below.
+>
+> https://feature-sliced.design/docs/reference/layers#import-rule-on-layers
+
+Example of a project structure that passes this rule (arrows signify imports):
+
+```mermaid
+flowchart BT
+  subgraph shared
+    subgraph shared/ui[ui]
+      shared/ui/styles.ts[styles.ts]
+      shared/ui/Button.tsx[Button.tsx]
+      shared/ui/TextField.tsx[TextField.tsx]
+      shared/ui/index.ts[index.ts]
+    end
+  end
+
+  subgraph entities
+    subgraph entities/user[user]
+      subgraph entities/user/ui[ui]
+        entities/user/ui/UserAvatar.tsx[UserAvatar.tsx]
+      end
+      entities/user/index.ts[index.ts]
+    end
+  end
+
+  subgraph features
+    subgraph features/auth[auth]
+      subgraph features/auth/ui[ui]
+        features/auth/ui/LoginForm.tsx[LoginForm.tsx]
+      end
+      features/auth/index.ts[index.ts]
+    end
+  end
+
+  subgraph pages
+    subgraph pages/editor[editor]
+      subgraph pages/editor/ui[ui]
+        pages/editor/ui/EditorPage.tsx[EditorPage.tsx]
+      end
+      pages/editor/index.ts[index.ts]
+    end
+  end
+
+  shared/ui/Button.tsx --> shared/ui/styles.ts
+  entities/user/ui/UserAvatar.tsx --> shared/ui/index.ts
+  features/auth/ui/LoginForm.tsx --> shared/ui/index.ts
+  features/auth/ui/LoginForm.tsx --> entities/user/index.ts
+  pages/editor/ui/EditorPage.tsx --> shared/ui/index.ts
+  pages/editor/ui/EditorPage.tsx --> entities/user/index.ts
+  pages/editor/ui/EditorPage.tsx --> features/auth/index.ts
+```
+
+Examples of project structures that fail this rule:
+
+```mermaid
+flowchart BT
+  subgraph shared
+    subgraph shared/ui[ui]
+      shared/ui/styles.ts[styles.ts]
+      shared/ui/Button.tsx[Button.tsx]
+      shared/ui/TextField.tsx[TextField.tsx]
+      shared/ui/index.ts[index.ts]
+    end
+  end
+
+  subgraph features
+    subgraph features/comments[comments]
+      subgraph features/comments/ui[ui]
+        features/comments/ui/CommentCard.tsx[CommentCard.tsx]
+      end
+      features/comments/index.ts[index.ts]
+    end
+  end
+
+  subgraph pages
+    subgraph pages/editor[editor]
+      subgraph pages/editor/ui[ui]
+        pages/editor/ui/EditorPage.tsx[EditorPage.tsx]
+        pages/editor/ui/Editor.tsx[Editor.tsx]
+      end
+      pages/editor/index.ts[index.ts]
+    end
+  end
+
+  shared/ui/Button.tsx --> shared/ui/styles.ts
+  shared/ui/TextField.tsx --> shared/ui/styles.ts
+  features/comments/ui/CommentCard.tsx --❌--> pages/editor/index.ts
+  pages/editor/ui/Editor.tsx --> shared/ui/index.ts
+  pages/editor/ui/EditorPage.tsx --> shared/ui/index.ts
+```
+
+```mermaid
+flowchart BT
+  subgraph shared
+    subgraph shared/ui[ui]
+      shared/ui/styles.ts[styles.ts]
+      shared/ui/Button.tsx[Button.tsx]
+      shared/ui/TextField.tsx[TextField.tsx]
+      shared/ui/index.ts[index.ts]
+    end
+  end
+
+  subgraph entities
+    subgraph entities/cart[cart]
+      subgraph entities/cart/ui[ui]
+        entities/cart/ui/SmallCart.tsx[SmallCart.tsx]
+      end
+      entities/cart/index.ts[index.ts]
+    end
+  end
+
+  subgraph app
+    subgraph app/ui[ui]
+      app/ui/index.ts[index.ts]
+    end
+    app/index.ts[index.ts]
+    app/root.ts[root.ts]
+  end
+
+  shared/ui/Button.tsx --> shared/ui/styles.ts
+  entities/cart/ui/SmallCart.tsx --❌--> app/index.ts
+  app/ui/index.ts --> shared/ui/index.ts
+```
+
+## Rationale
+
+This is one of the main rules of Feature-Sliced Design, it ensures low coupling and predictability in refactoring.

--- a/packages/steiger-plugin-fsd/src/no-higher-level-imports/README.md
+++ b/packages/steiger-plugin-fsd/src/no-higher-level-imports/README.md
@@ -1,6 +1,6 @@
 # `no-higher-level-imports`
 
-This rule forbids imports from higher layers in the Feature-Sliced Design architecture. This is in accordance to the import rule on layers:
+This rule forbids imports from higher layers. This is in accordance to the import rule on layers:
 
 > A module in a slice can only import other slices when they are located on layers strictly below.
 >

--- a/packages/steiger-plugin-fsd/src/no-higher-level-imports/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-higher-level-imports/index.spec.ts
@@ -1,0 +1,159 @@
+import { expect, it, vi } from 'vitest'
+
+import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
+import forbiddenImports from './index.js'
+
+vi.mock('tsconfck', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('tsconfck')>()),
+    parse: vi.fn(() =>
+      Promise.resolve({
+        tsconfig: {
+          compilerOptions: {
+            baseUrl: '/src/',
+            paths: {
+              '@/*': ['./*'],
+            },
+          },
+        },
+      }),
+    ),
+  }
+})
+
+vi.mock('node:fs', async (importOriginal) => {
+  const originalFs = await importOriginal<typeof import('fs')>()
+  const { createFsMocks } = await import('@steiger/toolkit/test')
+
+  return createFsMocks(
+    {
+      '/src/shared/ui/styles.ts': '',
+      '/src/shared/ui/Button.tsx': 'import styles from "./styles";',
+      '/src/shared/ui/TextField.tsx': 'import styles from "./styles";',
+      '/src/shared/ui/index.ts': '',
+      '/src/entities/user/ui/UserAvatar.tsx': 'import { Button } from "@/shared/ui"',
+      '/src/entities/user/index.ts': '',
+      '/src/entities/user/@x/product.ts': '',
+      '/src/entities/product/ui/ProductCard.tsx': 'import { UserAvatar } from "@/entities/user"',
+      '/src/entities/product/ui/GoodProductCard.tsx': 'import { UserAvatar } from "@/entities/user/@x/product"',
+      '/src/entities/product/index.ts': '',
+      '/src/entities/cart/ui/SmallCart.tsx': 'import { App } from "@/app"',
+      '/src/entities/cart/ui/BadSmallCart.tsx': 'import { UserAvatar } from "@/entities/user/@x/product"',
+      '/src/entities/cart/lib/count-cart-items.ts': 'import root from "@/app/root.ts"',
+      '/src/entities/cart/lib/index.ts': '',
+      '/src/entities/cart/index.ts': '',
+      '/src/features/comments/ui/CommentCard.tsx': 'import { styles } from "@/pages/editor"',
+      '/src/features/comments/index.ts': '',
+      '/src/pages/editor/ui/styles.ts': '',
+      '/src/pages/editor/ui/EditorPage.tsx': 'import { Button } from "@/shared/ui"; import { Editor } from "./Editor"',
+      '/src/pages/editor/ui/Editor.tsx': 'import { TextField } from "@/shared/ui"',
+      '/src/pages/editor/index.ts': '',
+      '/src/app': '',
+      '/src/app/ui/index.ts': '',
+      '/src/app/index.ts': '',
+      '/src/app/root.ts': '',
+    },
+    originalFs,
+  )
+})
+
+it('reports no errors on a project with only correct imports', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 shared
+        📂 ui
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 pages
+        📂 editor
+          📂 ui
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await forbiddenImports.check(root)).diagnostics).toEqual([])
+})
+
+it('reports errors on a project where a feature imports from a page', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 shared
+        📂 ui
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 features
+        📂 comments
+          📂 ui
+            📄 CommentCard.tsx
+          📄 index.ts
+      📂 pages
+        📂 editor
+          📂 ui
+            📄 styles.ts
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await forbiddenImports.check(root)).diagnostics.sort()).toEqual([
+    {
+      message: `Forbidden import from higher layer "pages".`,
+      location: { path: joinFromRoot('src', 'features', 'comments', 'ui', 'CommentCard.tsx') },
+    },
+  ])
+})
+
+it('reports errors on a project where a lower level imports from files that are direct children of a higher level', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 shared
+        📂 ui
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 cart
+          📄 index.ts
+          📂 lib
+            📄 count-cart-items.ts
+            📄 index.ts
+          📂 ui
+            📄 SmallCart.tsx
+      📂 pages
+        📂 editor
+          📂 ui
+            📄 styles.ts
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
+      📂 app
+        📂 ui
+          📄 index.ts
+        📄 index.ts
+        📄 root.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  const diagnostics = (await forbiddenImports.check(root)).diagnostics
+  expect(diagnostics).toEqual([
+    {
+      message: `Forbidden import from higher layer "app".`,
+      location: { path: joinFromRoot('src', 'entities', 'cart', 'lib', 'count-cart-items.ts') },
+    },
+    {
+      message: `Forbidden import from higher layer "app".`,
+      location: { path: joinFromRoot('src', 'entities', 'cart', 'ui', 'SmallCart.tsx') },
+    },
+  ])
+})

--- a/packages/steiger-plugin-fsd/src/no-higher-level-imports/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-higher-level-imports/index.spec.ts
@@ -1,7 +1,7 @@
 import { expect, it, vi } from 'vitest'
 
 import { joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
-import forbiddenImports from './index.js'
+import noHigherLevelImports from './index.js'
 
 vi.mock('tsconfck', async (importOriginal) => {
   return {
@@ -76,7 +76,7 @@ it('reports no errors on a project with only correct imports', async () => {
     joinFromRoot('src'),
   )
 
-  expect((await forbiddenImports.check(root)).diagnostics).toEqual([])
+  expect((await noHigherLevelImports.check(root)).diagnostics).toEqual([])
 })
 
 it('reports errors on a project where a feature imports from a page', async () => {
@@ -104,7 +104,7 @@ it('reports errors on a project where a feature imports from a page', async () =
     joinFromRoot('src'),
   )
 
-  expect((await forbiddenImports.check(root)).diagnostics.sort()).toEqual([
+  expect((await noHigherLevelImports.check(root)).diagnostics.sort()).toEqual([
     {
       message: `Forbidden import from higher layer "pages".`,
       location: { path: joinFromRoot('src', 'features', 'comments', 'ui', 'CommentCard.tsx') },
@@ -145,7 +145,7 @@ it('reports errors on a project where a lower level imports from files that are 
     joinFromRoot('src'),
   )
 
-  const diagnostics = (await forbiddenImports.check(root)).diagnostics
+  const diagnostics = (await noHigherLevelImports.check(root)).diagnostics
   expect(diagnostics).toEqual([
     {
       message: `Forbidden import from higher layer "app".`,

--- a/packages/steiger-plugin-fsd/src/no-higher-level-imports/index.ts
+++ b/packages/steiger-plugin-fsd/src/no-higher-level-imports/index.ts
@@ -1,0 +1,57 @@
+import * as fs from 'node:fs'
+import { layerSequence } from '@feature-sliced/filesystem'
+import precinct from 'precinct'
+const { paperwork } = precinct
+import { parse as parseNearestTsConfig } from 'tsconfck'
+import type { PartialDiagnostic, Rule } from '@steiger/toolkit'
+
+import { indexSourceFiles } from '../_lib/index-source-files.js'
+import { collectRelatedTsConfigs } from '../_lib/collect-related-ts-configs.js'
+import { resolveDependency } from '../_lib/resolve-dependency.js'
+import { NAMESPACE } from '../constants.js'
+
+const noHigherLevelImports = {
+  name: `${NAMESPACE}/no-higher-level-imports` as const,
+  async check(root) {
+    const diagnostics: Array<PartialDiagnostic> = []
+    const parseResult = await parseNearestTsConfig(root.children[0]?.path ?? root.path)
+    const tsConfigs = collectRelatedTsConfigs(parseResult)
+    const sourceFileIndex = indexSourceFiles(root)
+
+    for (const sourceFile of Object.values(sourceFileIndex)) {
+      const dependencies = paperwork(sourceFile.file.path, { includeCore: false, fileSystem: fs })
+      for (const dependency of dependencies) {
+        const resolvedDependency = resolveDependency(
+          dependency,
+          sourceFile.file.path,
+          tsConfigs,
+          fs.existsSync,
+          fs.existsSync,
+        )
+
+        if (resolvedDependency === null) {
+          continue
+        }
+
+        const dependencyLocation = sourceFileIndex[resolvedDependency]
+        if (dependencyLocation === undefined) {
+          continue
+        }
+
+        const thisLayerIndex = layerSequence.indexOf(sourceFile.layerName)
+        const dependencyLayerIndex = layerSequence.indexOf(dependencyLocation.layerName)
+
+        if (thisLayerIndex < dependencyLayerIndex) {
+          diagnostics.push({
+            message: `Forbidden import from higher layer "${dependencyLocation.layerName}".`,
+            location: { path: sourceFile.file.path },
+          })
+        }
+      }
+    }
+
+    return { diagnostics }
+  },
+} satisfies Rule
+
+export default noHigherLevelImports

--- a/packages/toolkit/src/create-configs.ts
+++ b/packages/toolkit/src/create-configs.ts
@@ -19,12 +19,14 @@ export function enableSpecificRules<Context, Rules extends Array<Rule>>(
   rulesToEnable: Rules,
   options?: { severity: Exclude<Severity, 'off'> },
 ): [Plugin<Context, Rules>, ConfigObject<Rules>] {
+  const namesOfRulesToEnable = rulesToEnable.map((ruleToEnable) => ruleToEnable.name)
+
   return [
     plugin,
     {
       rules: Object.fromEntries(
         plugin.ruleDefinitions
-          .filter((rule) => rulesToEnable.map((ruleToEnable) => ruleToEnable.name).includes(rule.name))
+          .filter((rule) => namesOfRulesToEnable.includes(rule.name))
           .map((rule) => [rule.name, options?.severity ?? 'error']),
       ) as {
         [key in RuleNames<Rules>]?: Severity | [Severity, OptionsForRule<Rules, key>]

--- a/packages/toolkit/src/create-configs.ts
+++ b/packages/toolkit/src/create-configs.ts
@@ -14,8 +14,77 @@ export function enableAllRules<Context, Rules extends Array<Rule>>(
   ]
 }
 
+export function enableSpecificRules<Context, Rules extends Array<Rule>>(
+  plugin: Plugin<Context, Rules>,
+  rulesToEnable: Rules,
+  options?: { severity: Exclude<Severity, 'off'> },
+): [Plugin<Context, Rules>, ConfigObject<Rules>] {
+  return [
+    plugin,
+    {
+      rules: Object.fromEntries(
+        plugin.ruleDefinitions
+          .filter((rule) => rulesToEnable.map((ruleToEnable) => ruleToEnable.name).includes(rule.name))
+          .map((rule) => [rule.name, options?.severity ?? 'error']),
+      ) as {
+        [key in RuleNames<Rules>]?: Severity | [Severity, OptionsForRule<Rules, key>]
+      },
+    },
+  ]
+}
+
 export function createConfigs<const Rules extends Array<Rule> = Array<Rule>, Keys extends string = string>(
   configs: Record<Keys, Config<Rules>>,
 ): Record<Keys, Config<Rules>> {
   return configs
+}
+
+if (import.meta.vitest) {
+  const { it, expect } = import.meta.vitest
+
+  it('enables only specific rules with the given severity', () => {
+    type TestContext = unknown
+
+    const mockPlugin: Plugin<TestContext> = {
+      meta: {
+        name: 'test',
+        version: '0.0.0',
+      },
+      ruleDefinitions: [
+        {
+          name: 'ruleA',
+          check: () => ({ diagnostics: [] }),
+        },
+        {
+          name: 'ruleB',
+          check: () => ({ diagnostics: [] }),
+        },
+        {
+          name: 'ruleC',
+          check: () => ({ diagnostics: [] }),
+        },
+      ],
+    }
+
+    const rulesToEnable = [
+      {
+        name: 'ruleA',
+        check: () => ({ diagnostics: [] }),
+      },
+      {
+        name: 'ruleC',
+        check: () => ({ diagnostics: [] }),
+      },
+    ]
+
+    const [plugin, config] = enableSpecificRules(mockPlugin, rulesToEnable, { severity: 'warn' })
+
+    expect(plugin).toEqual(mockPlugin)
+    expect(config).toEqual({
+      rules: {
+        ruleA: 'warn',
+        ruleC: 'warn',
+      },
+    })
+  })
 }

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -1,6 +1,6 @@
 export type * from '@steiger/types'
 
 export { findAllRecursively } from './find-all-recursively.js'
-export { enableAllRules, createConfigs } from './create-configs.js'
+export { enableAllRules, createConfigs, enableSpecificRules } from './create-configs.js'
 export { createPlugin } from './create-plugin.js'
 export type { ConfigObjectOf } from './config-object-of.js'


### PR DESCRIPTION
### Description
**1. Separated `forbidden-imports` into two more granular rules:**
  - `no-higher-level-imports`: Prevents imports from higher layers
  - `no-cross-imports`: Prevents cross-imports between slices on the same layer

**2. Disable new rules in recommend config for default**
- Implemented `enableSpecificRules` function which allows selectively enable only certain rules 

### Fixes
Fixes #182 