### PR TITLE
Fix bundle size workflow

### DIFF
--- a/.github/workflows/bundle-size-trusted.yaml
+++ b/.github/workflows/bundle-size-trusted.yaml
@@ -66,5 +66,5 @@ jobs:
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: ${{ steps.create-report.outputs.result }}
-          pr-number: ${{ github.event.workflow_run.pull_requests.number }}
+          pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           comment-tag: bundle-size

--- a/.github/workflows/bundle-size-untrusted.yaml
+++ b/.github/workflows/bundle-size-untrusted.yaml
@@ -29,9 +29,11 @@ jobs:
           if [[ "${{ matrix.branch }}" == "base" ]]; then
             echo "ref=${{ github.base_ref }}" >> $GITHUB_OUTPUT
             echo "repo=${{ github.repository }}" >> $GITHUB_OUTPUT
+            echo "branch_name=${{ github.base_ref }}" >> $GITHUB_OUTPUT
           else
             echo "ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
             echo "repo=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_OUTPUT
+            echo "branch_name=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout ${{ matrix.branch }} branch
@@ -49,10 +51,10 @@ jobs:
 
       - name: Collect sizes in bytes
         id: sizes
-        run: du -sb packages/*/dist > sizes-${{ matrix.branch }}.txt
+        run: du -sb packages/*/dist > sizes-${{ steps.vars.outputs.branch_name }}.txt
 
       - name: Upload the sizes
         uses: actions/upload-artifact@v4
         with:
-          name: sizes-${{ matrix.branch }}
-          path: sizes-${{ matrix.branch }}.txt
+          name: sizes-${{ steps.vars.outputs.branch_name }}
+          path: sizes-${{ steps.vars.outputs.branch_name }}.txt

--- a/.github/workflows/bundle-size-untrusted.yaml
+++ b/.github/workflows/bundle-size-untrusted.yaml
@@ -41,7 +41,6 @@ jobs:
         with:
           ref: ${{ steps.vars.outputs.ref }}
           repository: ${{ steps.vars.outputs.repo }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/bundle-size-untrusted.yaml
+++ b/.github/workflows/bundle-size-untrusted.yaml
@@ -19,13 +19,27 @@ jobs:
     strategy:
       matrix:
         branch:
-          - ${{ github.base_ref }}
-          - ${{ github.head_ref }}
+          - base
+          - head
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Set checkout parameters
+        id: vars
+        run: |
+          if [[ "${{ matrix.branch }}" == "base" ]]; then
+            echo "ref=${{ github.base_ref }}" >> $GITHUB_OUTPUT
+            echo "repo=${{ github.repository }}" >> $GITHUB_OUTPUT
+          else
+            echo "ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
+            echo "repo=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout ${{ matrix.branch }} branch
+        uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.branch }}
+          ref: ${{ steps.vars.outputs.ref }}
+          repository: ${{ steps.vars.outputs.repo }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
### Description
This PR fixes the workflow of `Bundle size` by ensuring that both the `base` branch and the `PR branch` **are correctly fetched**.

<img width="1444" alt="image" src="https://github.com/user-attachments/assets/05ea33a9-07a3-49bc-b479-c7eaaa32c3fc" />


Previously, both branches were fetched from the **same repository**, which caused issues when the PR came from a fork. This update fixes the logic to dynamically determine the correct ref (branch) and repository for each case, allowing us to:
	•	Check out the base branch from the upstream repository
	•	Check out the PR branch from the contributor’s fork

### Fixes
Fixes #184 