### PR TITLE
Bump up filesystem to v3.0.1

### DIFF
--- a/.changeset/violet-needles-grin.md
+++ b/.changeset/violet-needles-grin.md
@@ -1,0 +1,5 @@
+---
+'@feature-sliced/steiger-plugin': patch
+---
+
+Bump up filesystem to v3.0.1

--- a/.changeset/violet-needles-grin.md
+++ b/.changeset/violet-needles-grin.md
@@ -2,4 +2,4 @@
 '@feature-sliced/steiger-plugin': patch
 ---
 
-Bump up filesystem to v3.0.1
+Support `sliceA/@x/sliceB/index.ts` as cross-import public APIs

--- a/packages/steiger-plugin-fsd/package.json
+++ b/packages/steiger-plugin-fsd/package.json
@@ -34,7 +34,7 @@
     }
   ],
   "dependencies": {
-    "@feature-sliced/filesystem": "^3.0.0",
+    "@feature-sliced/filesystem": "^3.0.1",
     "fastest-levenshtein": "^1.0.16",
     "lodash-es": "^4.17.21",
     "pluralize": "^8.0.0",

--- a/packages/steiger-plugin-fsd/src/forbidden-imports/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/forbidden-imports/index.spec.ts
@@ -37,8 +37,12 @@ vi.mock('node:fs', async (importOriginal) => {
       '/src/entities/product/ui/ProductCard.tsx': 'import { UserAvatar } from "@/entities/user"',
       '/src/entities/product/ui/GoodProductCard.tsx': 'import { UserAvatar } from "@/entities/user/@x/product"',
       '/src/entities/product/index.ts': '',
+      '/src/entities/order/ui/OrderBadge.tsx': '',
+      '/src/entities/order/@x/cart/index.ts': '',
+      '/src/entities/order/index.ts': '',
       '/src/entities/cart/ui/SmallCart.tsx': 'import { App } from "@/app"',
       '/src/entities/cart/ui/BadSmallCart.tsx': 'import { UserAvatar } from "@/entities/user/@x/product"',
+      '/src/entities/cart/ui/CartItem.tsx': 'import { OrderBadge } from "@/entities/order/@x/cart"',
       '/src/entities/cart/lib/count-cart-items.ts': 'import root from "@/app/root.ts"',
       '/src/entities/cart/lib/index.ts': '',
       '/src/entities/cart/index.ts': '',
@@ -213,6 +217,40 @@ it('reports no errors on a project with cross-imports through @x', async () => {
         📂 product
           📂 ui
             📄 GoodProductCard.tsx
+          📄 index.ts
+      📂 pages
+        📂 editor
+          📂 ui
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await forbiddenImports.check(root)).diagnostics).toEqual([])
+})
+
+it('reports no errors on a project with cross-imports through @x index files', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 shared
+        📂 ui
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 order
+          📂 @x
+            📂 cart
+              📄 index.ts
+          📂 ui
+            📄 OrderBadge.tsx
+          📄 index.ts
+        📂 cart
+          📂 ui
+            📄 CartItem.tsx
           📄 index.ts
       📂 pages
         📂 editor

--- a/packages/steiger-plugin-fsd/src/no-cross-imports/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-cross-imports/index.spec.ts
@@ -37,8 +37,12 @@ vi.mock('node:fs', async (importOriginal) => {
       '/src/entities/product/ui/ProductCard.tsx': 'import { UserAvatar } from "@/entities/user"',
       '/src/entities/product/ui/GoodProductCard.tsx': 'import { UserAvatar } from "@/entities/user/@x/product"',
       '/src/entities/product/index.ts': '',
+      '/src/entities/order/ui/OrderBadge.tsx': '',
+      '/src/entities/order/@x/cart/index.ts': '',
+      '/src/entities/order/index.ts': '',
       '/src/entities/cart/ui/SmallCart.tsx': 'import { App } from "@/app"',
       '/src/entities/cart/ui/BadSmallCart.tsx': 'import { UserAvatar } from "@/entities/user/@x/product"',
+      '/src/entities/cart/ui/CartItem.tsx': 'import { OrderBadge } from "@/entities/order/@x/cart"',
       '/src/entities/cart/lib/count-cart-items.ts': 'import root from "@/app/root.ts"',
       '/src/entities/cart/lib/index.ts': '',
       '/src/entities/cart/index.ts': '',
@@ -134,6 +138,40 @@ it('reports no errors on a project with cross-imports through @x', async () => {
         📂 product
           📂 ui
             📄 GoodProductCard.tsx
+          📄 index.ts
+      📂 pages
+        📂 editor
+          📂 ui
+            📄 EditorPage.tsx
+            📄 Editor.tsx
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await noCrossImports.check(root)).diagnostics).toEqual([])
+})
+
+it('reports no errors on a project with cross-imports through @x index files', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 shared
+        📂 ui
+          📄 styles.ts
+          📄 Button.tsx
+          📄 TextField.tsx
+          📄 index.ts
+      📂 entities
+        📂 order
+          📂 @x
+            📂 cart
+              📄 index.ts
+          📂 ui
+            📄 OrderBadge.tsx
+          📄 index.ts
+        📂 cart
+          📂 ui
+            📄 CartItem.tsx
           📄 index.ts
       📂 pages
         📂 editor

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,8 +213,8 @@ importers:
   packages/steiger-plugin-fsd:
     dependencies:
       '@feature-sliced/filesystem':
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       fastest-levenshtein:
         specifier: ^1.0.16
         version: 1.0.16
@@ -308,7 +308,7 @@ importers:
         version: 15.14.0
       typescript-eslint:
         specifier: ^8.20.0
-        version: 8.20.0(eslint@9.18.0)(typescript@5.8.2)
+        version: 8.20.0(eslint@9.18.0)(typescript@5.8.3)
     devDependencies:
       eslint-config-prettier:
         specifier: ^10.0.1
@@ -740,8 +740,8 @@ packages:
     resolution: {integrity: sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@feature-sliced/filesystem@3.0.0':
-    resolution: {integrity: sha512-gg+wkH9GOj9qLS2U2eFoamVc1wSf2Zdc5QtO4ZDlnH4CW2Dus0THP4xwoDtxnOspavZpYJc1DHMkI+pcoNoNgQ==}
+  '@feature-sliced/filesystem@3.0.1':
+    resolution: {integrity: sha512-RlrfjhaX81o6E5OBc2A0tOLG/cZSOvcM+FpPlzEhTraIzBz8JmhxgwrYQbafMqiC+TOrqhd2pTLkU7PFQG1QdQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2562,8 +2562,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.8.2:
-    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3095,9 +3095,9 @@ snapshots:
       '@eslint/core': 0.10.0
       levn: 0.4.1
 
-  '@feature-sliced/filesystem@3.0.0':
+  '@feature-sliced/filesystem@3.0.1':
     dependencies:
-      typescript: 5.8.2
+      typescript: 5.8.3
 
   '@humanfs/core@0.19.1': {}
 
@@ -3404,32 +3404,32 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.20.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.8.2))(eslint@9.18.0)(typescript@5.8.2)':
+  '@typescript-eslint/eslint-plugin@8.20.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.8.3))(eslint@9.18.0)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.20.0(eslint@9.18.0)(typescript@5.8.2)
+      '@typescript-eslint/parser': 8.20.0(eslint@9.18.0)(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.20.0
-      '@typescript-eslint/type-utils': 8.20.0(eslint@9.18.0)(typescript@5.8.2)
-      '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.8.2)
+      '@typescript-eslint/type-utils': 8.20.0(eslint@9.18.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.20.0
       eslint: 9.18.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 2.0.0(typescript@5.8.2)
-      typescript: 5.8.2
+      ts-api-utils: 2.0.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.8.2)':
+  '@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.20.0
       '@typescript-eslint/types': 8.20.0
-      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.8.2)
+      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.20.0
       debug: 4.4.0
       eslint: 9.18.0
-      typescript: 5.8.2
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3438,14 +3438,14 @@ snapshots:
       '@typescript-eslint/types': 8.20.0
       '@typescript-eslint/visitor-keys': 8.20.0
 
-  '@typescript-eslint/type-utils@8.20.0(eslint@9.18.0)(typescript@5.8.2)':
+  '@typescript-eslint/type-utils@8.20.0(eslint@9.18.0)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.8.2)
-      '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.8.2)
+      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.8.3)
       debug: 4.4.0
       eslint: 9.18.0
-      ts-api-utils: 2.0.0(typescript@5.8.2)
-      typescript: 5.8.2
+      ts-api-utils: 2.0.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3468,7 +3468,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.20.0(typescript@5.8.2)':
+  '@typescript-eslint/typescript-estree@8.20.0(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.20.0
       '@typescript-eslint/visitor-keys': 8.20.0
@@ -3477,19 +3477,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 2.0.0(typescript@5.8.2)
-      typescript: 5.8.2
+      ts-api-utils: 2.0.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.20.0(eslint@9.18.0)(typescript@5.8.2)':
+  '@typescript-eslint/utils@8.20.0(eslint@9.18.0)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.18.0)
       '@typescript-eslint/scope-manager': 8.20.0
       '@typescript-eslint/types': 8.20.0
-      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.8.2)
+      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.8.3)
       eslint: 9.18.0
-      typescript: 5.8.2
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4859,9 +4859,9 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
-  ts-api-utils@2.0.0(typescript@5.8.2):
+  ts-api-utils@2.0.0(typescript@5.8.3):
     dependencies:
-      typescript: 5.8.2
+      typescript: 5.8.3
 
   ts-interface-checker@0.1.13: {}
 
@@ -4939,13 +4939,13 @@ snapshots:
 
   type-fest@1.4.0: {}
 
-  typescript-eslint@8.20.0(eslint@9.18.0)(typescript@5.8.2):
+  typescript-eslint@8.20.0(eslint@9.18.0)(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.20.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.8.2))(eslint@9.18.0)(typescript@5.8.2)
-      '@typescript-eslint/parser': 8.20.0(eslint@9.18.0)(typescript@5.8.2)
-      '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.8.2)
+      '@typescript-eslint/eslint-plugin': 8.20.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.8.3))(eslint@9.18.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.20.0(eslint@9.18.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.8.3)
       eslint: 9.18.0
-      typescript: 5.8.2
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4954,7 +4954,7 @@ snapshots:
 
   typescript@5.7.3: {}
 
-  typescript@5.8.2: {}
+  typescript@5.8.3: {}
 
   undici-types@5.26.5: {}
 


### PR DESCRIPTION
This pull request introduces several updates, including dependency upgrades and enhancements to test cases for cross-import validation. The changes ensure better compatibility and add test coverage for specific scenarios involving cross-imports through `@x` index files.

### Dependency Updates:
* Upgraded `@feature-sliced/filesystem` from version `3.0.0` to `3.0.1` in `package.json` 

### Test Enhancements:
* Added new test cases in `forbidden-imports/index.spec.ts` and `no-cross-imports/index.spec.ts` to validate scenarios with cross-imports through `@x` index files. 