### PR TITLE
Add repository field to public packages

### DIFF
--- a/.changeset/add-repository-field.md
+++ b/.changeset/add-repository-field.md
@@ -1,0 +1,9 @@
+---
+"@feature-sliced/steiger-plugin": patch
+"steiger": patch
+"@steiger/toolkit": patch
+---
+
+Add repository field to package.json files for better npm metadata
+
+Added repository field to all public packages pointing to the GitHub repository with appropriate directory paths. This helps users find the source code repository and specific package directories within the monorepo.

--- a/packages/steiger-plugin-fsd/package.json
+++ b/packages/steiger-plugin-fsd/package.json
@@ -33,6 +33,11 @@
       "url": "https://github.com/illright"
     }
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/feature-sliced/steiger.git",
+    "directory": "packages/steiger-plugin-fsd"
+  },
   "dependencies": {
     "@feature-sliced/filesystem": "^3.0.1",
     "fastest-levenshtein": "^1.0.16",

--- a/packages/steiger/package.json
+++ b/packages/steiger/package.json
@@ -15,6 +15,11 @@
       "url": "https://github.com/illright"
     }
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/feature-sliced/steiger.git",
+    "directory": "packages/steiger"
+  },
   "scripts": {
     "dev": "tsx src/cli.ts",
     "lint": "eslint .",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -35,6 +35,11 @@
       "url": "https://github.com/illright"
     }
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/feature-sliced/steiger.git",
+    "directory": "packages/toolkit"
+  },
   "peerDependencies": {
     "vitest": "^1.6.0 || ^2.1.8 || ^3.0.0-beta.2"
   },


### PR DESCRIPTION
Added repository metadata to all published npm packages (steiger, @feature-sliced/steiger-plugin, @steiger/toolkit) pointing to the GitHub repo with correct directory paths. Improves package discoverability and follows npm best practices.