### PR TITLE
fix: use fallback characters for std output snapshots

### DIFF
--- a/integration-tests/tests/__snapshots__/smoke-stderr-posix.txt
+++ b/integration-tests/tests/__snapshots__/smoke-stderr-posix.txt
@@ -1,42 +1,42 @@
 
 ┌ src/entities/user/api/getUser.ts
- Forbidden import from higher layer "app".
+× Forbidden import from higher layer "app".
 │
 └ fsd/forbidden-imports: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/forbidden-imports
 
 ┌ src/entities
- Inconsistent pluralization of slice names. Prefer all plural names
- Auto-fixable
+× Inconsistent pluralization of slice names. Prefer all plural names
+√ Auto-fixable
 │
 └ fsd/inconsistent-naming: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/inconsistent-naming
 
 ┌ src/entities/user
- This slice has no references. Consider removing it.
+× This slice has no references. Consider removing it.
 │
 └ fsd/insignificant-slice: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/insignificant-slice
 
 ┌ src/entities/users
- This slice has no references. Consider removing it.
+× This slice has no references. Consider removing it.
 │
 └ fsd/insignificant-slice: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/insignificant-slice
 
 ┌ src/entities/user/api/getUser.ts
- Forbidden sidestep of public API when importing from "@/app/ui/App".
+× Forbidden sidestep of public API when importing from "@/app/ui/App".
 │
 └ fsd/no-public-api-sidestep: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-public-api-sidestep
 
 ┌ src/entities/user/ui/api
- Having a folder with the name "api" inside a segment could be confusing because that name is commonly used for segments. Consider renaming it.
+× Having a folder with the name "api" inside a segment could be confusing because that name is commonly used for segments. Consider renaming it.
 │
 └ fsd/no-reserved-folder-names: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-reserved-folder-names
 
 ┌ src/app/ui
- Layer "app" should not have "ui" segment.
+× Layer "app" should not have "ui" segment.
 │
 └ fsd/no-ui-in-app: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-ui-in-app
 
 ┌ src/processes
- Layer "processes" is deprecated, avoid using it
+× Layer "processes" is deprecated, avoid using it
 │
 └ fsd/no-processes: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-processes
 

--- a/integration-tests/tests/__snapshots__/smoke-stderr-posix.txt
+++ b/integration-tests/tests/__snapshots__/smoke-stderr-posix.txt
@@ -1,42 +1,42 @@
 
 ┌ src/entities/user/api/getUser.ts
-✘ Forbidden import from higher layer "app".
+ Forbidden import from higher layer "app".
 │
 └ fsd/forbidden-imports: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/forbidden-imports
 
 ┌ src/entities
-✘ Inconsistent pluralization of slice names. Prefer all plural names
-✔ Auto-fixable
+ Inconsistent pluralization of slice names. Prefer all plural names
+ Auto-fixable
 │
 └ fsd/inconsistent-naming: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/inconsistent-naming
 
 ┌ src/entities/user
-✘ This slice has no references. Consider removing it.
+ This slice has no references. Consider removing it.
 │
 └ fsd/insignificant-slice: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/insignificant-slice
 
 ┌ src/entities/users
-✘ This slice has no references. Consider removing it.
+ This slice has no references. Consider removing it.
 │
 └ fsd/insignificant-slice: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/insignificant-slice
 
 ┌ src/entities/user/api/getUser.ts
-✘ Forbidden sidestep of public API when importing from "@/app/ui/App".
+ Forbidden sidestep of public API when importing from "@/app/ui/App".
 │
 └ fsd/no-public-api-sidestep: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-public-api-sidestep
 
 ┌ src/entities/user/ui/api
-✘ Having a folder with the name "api" inside a segment could be confusing because that name is commonly used for segments. Consider renaming it.
+ Having a folder with the name "api" inside a segment could be confusing because that name is commonly used for segments. Consider renaming it.
 │
 └ fsd/no-reserved-folder-names: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-reserved-folder-names
 
 ┌ src/app/ui
-✘ Layer "app" should not have "ui" segment.
+ Layer "app" should not have "ui" segment.
 │
 └ fsd/no-ui-in-app: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-ui-in-app
 
 ┌ src/processes
-✘ Layer "processes" is deprecated, avoid using it
+ Layer "processes" is deprecated, avoid using it
 │
 └ fsd/no-processes: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-processes
 

--- a/integration-tests/tests/__snapshots__/smoke-stderr-windows.txt
+++ b/integration-tests/tests/__snapshots__/smoke-stderr-windows.txt
@@ -1,42 +1,42 @@
 
 ┌ src\entities\user\api\getUser.ts
-× Forbidden import from higher layer "app".
+ Forbidden import from higher layer "app".
 │
 └ fsd/forbidden-imports: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/forbidden-imports
 
 ┌ src\entities
-× Inconsistent pluralization of slice names. Prefer all plural names
-√ Auto-fixable
+ Inconsistent pluralization of slice names. Prefer all plural names
+ Auto-fixable
 │
 └ fsd/inconsistent-naming: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/inconsistent-naming
 
 ┌ src\entities\user
-× This slice has no references. Consider removing it.
+ This slice has no references. Consider removing it.
 │
 └ fsd/insignificant-slice: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/insignificant-slice
 
 ┌ src\entities\users
-× This slice has no references. Consider removing it.
+ This slice has no references. Consider removing it.
 │
 └ fsd/insignificant-slice: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/insignificant-slice
 
 ┌ src\entities\user\api\getUser.ts
-× Forbidden sidestep of public API when importing from "@/app/ui/App".
+ Forbidden sidestep of public API when importing from "@/app/ui/App".
 │
 └ fsd/no-public-api-sidestep: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-public-api-sidestep
 
 ┌ src\entities\user\ui\api
-× Having a folder with the name "api" inside a segment could be confusing because that name is commonly used for segments. Consider renaming it.
+ Having a folder with the name "api" inside a segment could be confusing because that name is commonly used for segments. Consider renaming it.
 │
 └ fsd/no-reserved-folder-names: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-reserved-folder-names
 
 ┌ src\app\ui
-× Layer "app" should not have "ui" segment.
+ Layer "app" should not have "ui" segment.
 │
 └ fsd/no-ui-in-app: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-ui-in-app
 
 ┌ src\processes
-× Layer "processes" is deprecated, avoid using it
+ Layer "processes" is deprecated, avoid using it
 │
 └ fsd/no-processes: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-processes
 

--- a/integration-tests/tests/__snapshots__/smoke-stderr-windows.txt
+++ b/integration-tests/tests/__snapshots__/smoke-stderr-windows.txt
@@ -1,42 +1,42 @@
 
 ┌ src\entities\user\api\getUser.ts
- Forbidden import from higher layer "app".
+× Forbidden import from higher layer "app".
 │
 └ fsd/forbidden-imports: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/forbidden-imports
 
 ┌ src\entities
- Inconsistent pluralization of slice names. Prefer all plural names
- Auto-fixable
+× Inconsistent pluralization of slice names. Prefer all plural names
+√ Auto-fixable
 │
 └ fsd/inconsistent-naming: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/inconsistent-naming
 
 ┌ src\entities\user
- This slice has no references. Consider removing it.
+× This slice has no references. Consider removing it.
 │
 └ fsd/insignificant-slice: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/insignificant-slice
 
 ┌ src\entities\users
- This slice has no references. Consider removing it.
+× This slice has no references. Consider removing it.
 │
 └ fsd/insignificant-slice: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/insignificant-slice
 
 ┌ src\entities\user\api\getUser.ts
- Forbidden sidestep of public API when importing from "@/app/ui/App".
+× Forbidden sidestep of public API when importing from "@/app/ui/App".
 │
 └ fsd/no-public-api-sidestep: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-public-api-sidestep
 
 ┌ src\entities\user\ui\api
- Having a folder with the name "api" inside a segment could be confusing because that name is commonly used for segments. Consider renaming it.
+× Having a folder with the name "api" inside a segment could be confusing because that name is commonly used for segments. Consider renaming it.
 │
 └ fsd/no-reserved-folder-names: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-reserved-folder-names
 
 ┌ src\app\ui
- Layer "app" should not have "ui" segment.
+× Layer "app" should not have "ui" segment.
 │
 └ fsd/no-ui-in-app: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-ui-in-app
 
 ┌ src\processes
- Layer "processes" is deprecated, avoid using it
+× Layer "processes" is deprecated, avoid using it
 │
 └ fsd/no-processes: https://github.com/feature-sliced/steiger/tree/master/packages/steiger-plugin-fsd/src/no-processes
 

--- a/integration-tests/tests/smoke.test.ts
+++ b/integration-tests/tests/smoke.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { exec } from 'tinyexec'
+import figures from 'figures'
 
 import { expect, test } from 'vitest'
 
@@ -13,6 +14,8 @@ const steiger = await getSteigerBinPath()
 const kitchenSinkExample = join(dirname(fileURLToPath(import.meta.url)), '../../examples/kitchen-sink-of-fsd-issues')
 const pathPlatform = os.platform() === 'win32' ? 'windows' : 'posix'
 
+const unsafeChars = new RegExp(`[${figures.cross}${figures.warning}${figures.tick}]`, 'g')
+
 test('basic functionality in the kitchen sink example project', async () => {
   const project = join(temporaryDirectory, 'smoke')
   await fs.rm(project, { recursive: true, force: true })
@@ -20,5 +23,7 @@ test('basic functionality in the kitchen sink example project', async () => {
 
   const { stderr } = await exec('node', [steiger, 'src'], { nodeOptions: { cwd: project, env: { NO_COLOR: '1' } } })
 
-  await expect(stderr).toMatchFileSnapshot(join('__snapshots__', `smoke-stderr-${pathPlatform}.txt`))
+  await expect(stderr.replaceAll(unsafeChars, '')).toMatchFileSnapshot(
+    join('__snapshots__', `smoke-stderr-${pathPlatform}.txt`),
+  )
 })

--- a/integration-tests/tests/smoke.test.ts
+++ b/integration-tests/tests/smoke.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { exec } from 'tinyexec'
-import figures from 'figures'
+import { replaceSymbols } from 'figures'
 
 import { expect, test } from 'vitest'
 
@@ -14,16 +14,13 @@ const steiger = await getSteigerBinPath()
 const kitchenSinkExample = join(dirname(fileURLToPath(import.meta.url)), '../../examples/kitchen-sink-of-fsd-issues')
 const pathPlatform = os.platform() === 'win32' ? 'windows' : 'posix'
 
-const unsafeChars = new RegExp(`[${figures.cross}${figures.warning}${figures.tick}]`, 'g')
-
 test('basic functionality in the kitchen sink example project', async () => {
   const project = join(temporaryDirectory, 'smoke')
   await fs.rm(project, { recursive: true, force: true })
   await fs.cp(kitchenSinkExample, project, { recursive: true })
 
-  const { stderr } = await exec('node', [steiger, 'src'], { nodeOptions: { cwd: project, env: { NO_COLOR: '1' } } })
+  let { stderr } = await exec('node', [steiger, 'src'], { nodeOptions: { cwd: project, env: { NO_COLOR: '1' } } })
+  stderr = replaceSymbols(stderr, { useFallback: true })
 
-  await expect(stderr.replaceAll(unsafeChars, '')).toMatchFileSnapshot(
-    join('__snapshots__', `smoke-stderr-${pathPlatform}.txt`),
-  )
+  await expect(stderr).toMatchFileSnapshot(join('__snapshots__', `smoke-stderr-${pathPlatform}.txt`))
 })


### PR DESCRIPTION
Chars from `figures` package depend on the current Windows shell, so snapshots will differ between different environments (currently tests were OK in cmd, but were failing in PowerShell)

I removed all symbols that could theoretically cause this issue