### PR TITLE
fix(plugin): add root export entry for steiger plugin

### DIFF
--- a/.changeset/great-numbers-listen.md
+++ b/.changeset/great-numbers-listen.md
@@ -1,0 +1,5 @@
+---
+'@feature-sliced/steiger-plugin': patch
+---
+
+Fix package root exports in package.json

--- a/packages/steiger-plugin-fsd/package.json
+++ b/packages/steiger-plugin-fsd/package.json
@@ -12,8 +12,10 @@
     "typecheck": "tsc --noEmit"
   },
   "exports": {
-    "types": "./dist/index.d.ts",
-    "import": "./dist/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
     "dist",


### PR DESCRIPTION
Fix package root exports for `@feature-sliced/steiger-plugin`.

Closes #225