### PR TITLE
fix(ci): use stable artifact names in bundle size workflow

### DIFF
--- a/.github/workflows/bundle-size-trusted.yaml
+++ b/.github/workflows/bundle-size-trusted.yaml
@@ -47,8 +47,8 @@ jobs:
               }
             }
             const fs = require('fs');
-            const sizes = parseDuOutput(fs.readFileSync('sizes-master.txt', 'utf8'));
-            const sizesPR = parseDuOutput(fs.readFileSync(`sizes-${${{ toJson(github.event.workflow_run.head_branch) }}}.txt`, 'utf8'));
+            const sizes = parseDuOutput(fs.readFileSync('sizes-base.txt', 'utf8'));
+            const sizesPR = parseDuOutput(fs.readFileSync('sizes-head.txt', 'utf8'));
             core.summary.addHeading('📊 Package size report', '3');
             core.summary.addTable([
               ['Package', 'Before', 'After'].map((data) => ({ data, header: true })),

--- a/.github/workflows/bundle-size-untrusted.yaml
+++ b/.github/workflows/bundle-size-untrusted.yaml
@@ -29,11 +29,9 @@ jobs:
           if [[ "${{ matrix.branch }}" == "base" ]]; then
             echo "ref=${{ github.base_ref }}" >> $GITHUB_OUTPUT
             echo "repo=${{ github.repository }}" >> $GITHUB_OUTPUT
-            echo "branch_name=${{ github.base_ref }}" >> $GITHUB_OUTPUT
           else
             echo "ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
             echo "repo=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_OUTPUT
-            echo "branch_name=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout ${{ matrix.branch }} branch
@@ -50,10 +48,10 @@ jobs:
 
       - name: Collect sizes in bytes
         id: sizes
-        run: du -sb packages/*/dist > sizes-${{ steps.vars.outputs.branch_name }}.txt
+        run: du -sb packages/*/dist > sizes-${{ matrix.branch }}.txt
 
       - name: Upload the sizes
         uses: actions/upload-artifact@v4
         with:
-          name: sizes-${{ steps.vars.outputs.branch_name }}
-          path: sizes-${{ steps.vars.outputs.branch_name }}.txt
+          name: sizes-${{ matrix.branch }}
+          path: sizes-${{ matrix.branch }}.txt


### PR DESCRIPTION
Use stable `base` and `head` artifact names in the bundle size workflow.

Closes #202