### PR TITLE
fix(fsd): ignore neutral words in inconsistent naming

### DIFF
--- a/.changeset/honest-nights-prove.md
+++ b/.changeset/honest-nights-prove.md
@@ -1,0 +1,5 @@
+---
+'@feature-sliced/steiger-plugin': patch
+---
+
+Ignore neutral words like k8s, kubernetes, and media in fsd/inconsistent-naming

--- a/packages/steiger-plugin-fsd/src/inconsistent-naming/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/inconsistent-naming/index.spec.ts
@@ -73,3 +73,34 @@ it('prefers the singular form when there are more singular slices', () => {
     },
   ])
 })
+
+it('ignores neutral words like k8s and kubernetes when checking pluralization', () => {
+  const root = parseIntoFsdRoot(`
+    📂 entities
+      📂 user
+        📂 ui
+        📄 index.ts
+      📂 k8s
+        📂 ui
+        📄 index.ts
+      📂 kubernetes
+        📂 ui
+        📄 index.ts
+  `)
+
+  expect(inconsistentNaming.check(root)).toEqual({ diagnostics: [] })
+})
+
+it('ignores uncountable words like media when checking pluralization', () => {
+  const root = parseIntoFsdRoot(`
+    📂 entities
+      📂 user
+        📂 ui
+        📄 index.ts
+      📂 media
+        📂 ui
+        📄 index.ts
+  `)
+
+  expect(inconsistentNaming.check(root)).toEqual({ diagnostics: [] })
+})

--- a/packages/steiger-plugin-fsd/src/inconsistent-naming/index.ts
+++ b/packages/steiger-plugin-fsd/src/inconsistent-naming/index.ts
@@ -8,6 +8,8 @@ import type { PartialDiagnostic, Rule } from '@steiger/toolkit'
 import { groupSlices } from '../_lib/group-slices.js'
 import { NAMESPACE } from '../constants.js'
 
+const neutralWords = new Set(['k8s', 'kubernetes', 'media'])
+
 /** Detect inconsistent naming of slices on layers (singular vs plural) */
 const inconsistentNaming = {
   name: `${NAMESPACE}/inconsistent-naming` as const,
@@ -22,7 +24,8 @@ const inconsistentNaming = {
     const slices = getSlices(entities)
     const sliceNames = groupSlices(Object.keys(slices))
     for (const [groupPrefix, group] of Object.entries(sliceNames)) {
-      const [pluralNames, singularNames] = partition(group, isPlural)
+      const [, namesToCheck] = partition(group, isNeutralWord)
+      const [pluralNames, singularNames] = partition(namesToCheck, isPlural)
 
       if (pluralNames.length > 0 && singularNames.length > 0) {
         const message = 'Inconsistent pluralization of slice names'
@@ -56,3 +59,7 @@ const inconsistentNaming = {
 } satisfies Rule
 
 export default inconsistentNaming
+
+function isNeutralWord(name: string) {
+  return neutralWords.has(name.toLowerCase())
+}


### PR DESCRIPTION
Ignore neutral words like `k8s`, `kubernetes`, and `media` in `fsd/inconsistent-naming`.

Closes #198
Closes #221