### PR TITLE
perf: add fs cache for CPU-heavy rules

### DIFF
--- a/.changeset/red-corners-vanish.md
+++ b/.changeset/red-corners-vanish.md
@@ -1,0 +1,6 @@
+---
+'@feature-sliced/steiger-plugin': minor
+'@steiger/toolkit': patch
+---
+
+add fs cache for import rules

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,3 @@
+{
+  "formatter": "prettier"
+}

--- a/packages/steiger-plugin-fsd/src/_language-tools/astro.spec.ts
+++ b/packages/steiger-plugin-fsd/src/_language-tools/astro.spec.ts
@@ -1,17 +1,23 @@
-import { expect, it } from 'vitest'
+import { expect, it, vi } from 'vitest'
+
+import { createMockedNodeFs } from './mock-node-fs.js'
+
+vi.mock('node:fs', () =>
+  createMockedNodeFs({
+    '/src/Button.astro': `
+---
+import Button from '@components/controls/Button.astro';
+import logoUrl from '@assets/logo.png?url';
+---
+
+<h1>Hello</h1>
+  `,
+  }),
+)
+
 import { extractDependencies } from './index.js'
 
 it('extracts esm dependencies from Astro source code', async () => {
-  const dependencies = await extractDependencies(
-    'astro',
-    `
-    ---
-    import Button from '@components/controls/Button.astro';
-    import logoUrl from '@assets/logo.png?url';
-    ---
-
-    <h1>Hello</h1>
-  `,
-  )
+  const dependencies = await extractDependencies('/src/Button.astro')
   expect(dependencies).toEqual(['@components/controls/Button.astro', '@assets/logo.png?url'])
 })

--- a/packages/steiger-plugin-fsd/src/_language-tools/index.ts
+++ b/packages/steiger-plugin-fsd/src/_language-tools/index.ts
@@ -1,7 +1,9 @@
 import { join, extname, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { isBuiltin } from 'node:module'
+import { readFileSync } from 'node:fs'
 import { Parser, Query, Language, Range, type Tree } from 'web-tree-sitter'
+import { createFSCache } from '../_lib/fs-cache.js'
 
 // TODO: replace with import.meta.dirname when upgrading to nodejs 20/22
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -136,28 +138,39 @@ function processExtractor(extractor: Extractor, tree: Tree, importType?: 'static
   return result
 }
 
-export async function extractDependencies(
-  sourceType: string,
-  sourceCode: string,
-  options?: {
-    includeBuiltIns?: boolean
-    importType?: 'static' | 'dynamic'
-  },
-): Promise<string[]> {
-  const includeBuiltIns = options?.includeBuiltIns ?? false
-  const importType = options?.importType
+interface Dependency {
+  path: string
+  builtIn: boolean
+  dynamic: boolean
+}
 
-  const extractor = extractors.find((extractor) => extractor.type === sourceType)
-  if (!extractor) throw new Error(`No extractor found for "${sourceType}"`)
+const cache = createFSCache<Dependency[]>()
 
-  const dependencies: string[] = []
+function extractAllDependencies(path: string): Dependency[] {
+  const extension = extname(path)
+  const extractor = extractors.find((extractor) => extractor.extensions.includes(extension))
+  if (!extractor) throw new Error(`No extractor found for "${extension}"`)
 
+  const dependencies: Dependency[] = []
+
+  const sourceCode = readFileSync(path, 'utf8')
   const parser = new Parser()
   parser.setLanguage(extractor.language)
   const tree = parser.parse(sourceCode)
-  if (tree === null) return dependencies
+  if (tree === null) return []
 
-  dependencies.push(...processExtractor(extractor, tree, importType))
+  dependencies.push(
+    ...processExtractor(extractor, tree, 'dynamic').map((dep) => ({
+      path: dep,
+      builtIn: isBuiltin(dep),
+      dynamic: true,
+    })),
+    ...processExtractor(extractor, tree, 'static').map((dep) => ({
+      path: dep,
+      builtIn: isBuiltin(dep),
+      dynamic: false,
+    })),
+  )
 
   for (const { query, lang } of extractor.injections) {
     const injectedExtractor = extractors.find((extractor) => extractor.type === lang)
@@ -182,14 +195,49 @@ export async function extractDependencies(
     parser.setLanguage(injectedExtractor.language)
     const injectedTree = parser.parse(sourceCode, null, { includedRanges })
     if (injectedTree === null) continue
-    dependencies.push(...processExtractor(injectedExtractor, injectedTree, importType))
+    dependencies.push(
+      ...processExtractor(injectedExtractor, injectedTree, 'dynamic').map((dep) => ({
+        path: dep,
+        builtIn: isBuiltin(dep),
+        dynamic: true,
+      })),
+      ...processExtractor(injectedExtractor, injectedTree, 'static').map((dep) => ({
+        path: dep,
+        builtIn: isBuiltin(dep),
+        dynamic: false,
+      })),
+    )
     injectedTree.delete()
   }
 
   tree.delete()
 
-  if (includeBuiltIns === false) {
-    return dependencies.filter((dep) => !isBuiltin(dep))
-  }
   return dependencies
+}
+
+export async function extractDependencies(
+  path: string,
+  options?: {
+    includeBuiltIns?: boolean
+    importType?: 'static' | 'dynamic'
+  },
+): Promise<string[]> {
+  const includeBuiltIns = options?.includeBuiltIns ?? false
+  const importType = options?.importType
+
+  let dependencies = cache.get(path)
+  if (!dependencies) {
+    dependencies = extractAllDependencies(path)
+    cache.set(path, dependencies)
+  }
+
+  return dependencies
+    .filter((dep) => {
+      if (includeBuiltIns === false && dep.builtIn === true) return false
+      if (importType === 'dynamic' && dep.dynamic === false) return false
+      if (importType === 'static' && dep.dynamic === true) return false
+
+      return true
+    })
+    .map((dep) => dep.path)
 }

--- a/packages/steiger-plugin-fsd/src/_language-tools/mock-node-fs.ts
+++ b/packages/steiger-plugin-fsd/src/_language-tools/mock-node-fs.ts
@@ -1,0 +1,37 @@
+import type { readFileSync, statSync } from 'node:fs'
+
+/**
+ * Creates a mocked fs module that returns the provided files.
+ *
+ * @param files - Map of file paths to their mocked string contents. Reads of these paths return the given content.
+ * @param importOriginal - Optional vitest factory callback resolving the real `node:fs` module. When provided, reads of unmocked paths fall back to the real fs; otherwise they throw.
+ * @example
+ * ```ts
+ * vi.mock('node:fs', () => createMockedNodeFs({ 'index.js': 'const a = 2;' }))
+ *
+ * // allow original fs methods for other files
+ * vi.mock('node:fs', (importOriginal) => createMockedNodeFs({ 'index.js': 'const a = 2;' }, importOriginal))
+ * ```
+ */
+export async function createMockedNodeFs(files: Record<string, string>, importOriginal?: () => Promise<unknown>) {
+  const actual = (await importOriginal?.()) as
+    | { readFileSync: typeof readFileSync; statSync: typeof statSync }
+    | undefined
+
+  return {
+    ...actual,
+    // Add other mocked fs methods here if needed
+    readFileSync: ((path: string, options) => {
+      if (path in files) return files[path]
+
+      if (!actual) throw new Error(`File "${path}" is not mocked`)
+      return actual.readFileSync(path, options)
+    }) as typeof readFileSync,
+    statSync: (path: string) => {
+      if (path in files) return { mtimeMs: 0 }
+
+      if (!actual) throw new Error(`File "${path}" is not mocked`)
+      return actual.statSync(path)
+    },
+  }
+}

--- a/packages/steiger-plugin-fsd/src/_language-tools/svelte.spec.ts
+++ b/packages/steiger-plugin-fsd/src/_language-tools/svelte.spec.ts
@@ -1,10 +1,10 @@
-import { expect, it } from 'vitest'
-import { extractDependencies } from './index.js'
+import { expect, it, vi } from 'vitest'
 
-it('extracts esm dependencies from Svelte source code', async () => {
-  const dependencies = await extractDependencies(
-    'svelte',
-    `
+import { createMockedNodeFs } from './mock-node-fs.js'
+
+vi.mock('node:fs', () =>
+  createMockedNodeFs({
+    '/src/App.svelte': `
       <script>
         // [Learn1]Imports content from another Svelte file.
         // SvelteKit automatically makes files under "src/lib" available using the "$lib" import alias.(https://svelte.dev/docs/kit/$lib)
@@ -64,6 +64,12 @@ it('extracts esm dependencies from Svelte source code', async () => {
         }
       </style>
   `,
-  )
+  }),
+)
+
+import { extractDependencies } from './index.js'
+
+it('extracts esm dependencies from Svelte source code', async () => {
+  const dependencies = await extractDependencies('/src/App.svelte')
   expect(dependencies).toEqual(['$lib/components/Hello.svelte', '$lib/components/Counter.svelte'])
 })

--- a/packages/steiger-plugin-fsd/src/_language-tools/typescript.spec.ts
+++ b/packages/steiger-plugin-fsd/src/_language-tools/typescript.spec.ts
@@ -1,34 +1,36 @@
-import { expect, it } from 'vitest'
-import { extractDependencies } from './index.js'
+import { expect, it, vi } from 'vitest'
 
-it('extracts esm dependencies from TypeScript source code', async () => {
-  const dependencies = await extractDependencies(
-    'tsx',
-    `
+import { createMockedNodeFs } from './mock-node-fs.js'
+
+vi.mock('node:fs', () =>
+  createMockedNodeFs({
+    '/src/esm.tsx': `
     import isEven from 'is-even'
   `,
-  )
-  expect(dependencies).toEqual(['is-even'])
-})
-
-it('extracts cjs dependencies from TypeScript source code', async () => {
-  const dependencies = await extractDependencies(
-    'tsx',
-    `
+    '/src/cjs.tsx': `
     const isEven = require('is-even')
   `,
-  )
-  expect(dependencies).toEqual(['is-even'])
-})
-
-it('extracts dynamic dependencies from TypeScript source code', async () => {
-  const dependencies = await extractDependencies(
-    'tsx',
-    `
+    '/src/dynamic.tsx': `
     async function foo() {
       const isEven = await import('is-even')
     }
   `,
-  )
+  }),
+)
+
+import { extractDependencies } from './index.js'
+
+it('extracts esm dependencies from TypeScript source code', async () => {
+  const dependencies = await extractDependencies('/src/esm.tsx')
+  expect(dependencies).toEqual(['is-even'])
+})
+
+it('extracts cjs dependencies from TypeScript source code', async () => {
+  const dependencies = await extractDependencies('/src/cjs.tsx')
+  expect(dependencies).toEqual(['is-even'])
+})
+
+it('extracts dynamic dependencies from TypeScript source code', async () => {
+  const dependencies = await extractDependencies('/src/dynamic.tsx')
   expect(dependencies).toEqual(['is-even'])
 })

--- a/packages/steiger-plugin-fsd/src/_language-tools/vue.spec.ts
+++ b/packages/steiger-plugin-fsd/src/_language-tools/vue.spec.ts
@@ -1,10 +1,10 @@
-import { expect, it } from 'vitest'
-import { extractDependencies } from './index.js'
+import { expect, it, vi } from 'vitest'
 
-it('extracts esm dependencies from Vue source code', async () => {
-  const dependencies = await extractDependencies(
-    'vue',
-    `
+import { createMockedNodeFs } from './mock-node-fs.js'
+
+vi.mock('node:fs', () =>
+  createMockedNodeFs({
+    '/src/App.vue': `
     <script>
       import Button from '@shared/ui/Button.vue';
     </script>
@@ -15,6 +15,12 @@ it('extracts esm dependencies from Vue source code', async () => {
 
     <h1>Hello</h1>
   `,
-  )
+  }),
+)
+
+import { extractDependencies } from './index.js'
+
+it('extracts esm dependencies from Vue source code', async () => {
+  const dependencies = await extractDependencies('/src/App.vue')
   expect(dependencies).toEqual(['@shared/ui/Button.vue', 'vue'])
 })

--- a/packages/steiger-plugin-fsd/src/_lib/fs-cache.ts
+++ b/packages/steiger-plugin-fsd/src/_lib/fs-cache.ts
@@ -1,0 +1,21 @@
+import { statSync } from 'node:fs'
+
+export function createFSCache<T>() {
+  const cache = new Map<string, { mtime: number; value: T }>()
+
+  function has(path: string): boolean {
+    const data = cache.get(path)
+    return data !== undefined && data.mtime === statSync(path).mtimeMs
+  }
+
+  function get(path: string): T | undefined {
+    if (!has(path)) return undefined
+    return cache.get(path)!.value
+  }
+
+  function set(path: string, value: T): void {
+    cache.set(path, { mtime: statSync(path).mtimeMs, value })
+  }
+
+  return { has, get, set }
+}

--- a/packages/steiger-plugin-fsd/src/forbidden-imports/index.ts
+++ b/packages/steiger-plugin-fsd/src/forbidden-imports/index.ts
@@ -22,7 +22,7 @@ const forbiddenImports = {
       const sourceType = getSourceType(sourceFile.file.path)
       if (!sourceType) continue
 
-      const dependencies = await extractDependencies(sourceType, fs.readFileSync(sourceFile.file.path, 'utf8'))
+      const dependencies = await extractDependencies(sourceFile.file.path)
       for (const dependency of dependencies) {
         const resolvedDependency = resolveDependency(
           dependency,

--- a/packages/steiger-plugin-fsd/src/import-locality/index.ts
+++ b/packages/steiger-plugin-fsd/src/import-locality/index.ts
@@ -20,7 +20,7 @@ const importLocality = {
       const sourceType = getSourceType(sourceFile.file.path)
       if (!sourceType) continue
 
-      const dependencies = await extractDependencies(sourceType, fs.readFileSync(sourceFile.file.path, 'utf8'))
+      const dependencies = await extractDependencies(sourceFile.file.path)
       for (const dependency of dependencies) {
         const resolvedDependency = resolveDependency(
           dependency,

--- a/packages/steiger-plugin-fsd/src/insignificant-slice/index.ts
+++ b/packages/steiger-plugin-fsd/src/insignificant-slice/index.ts
@@ -64,7 +64,7 @@ async function traceSliceReferences(root: Folder) {
     const sourceType = getSourceType(sourceFile.file.path)
     if (!sourceType) continue
 
-    const dependencies = await extractDependencies(sourceType, fs.readFileSync(sourceFile.file.path, 'utf8'))
+    const dependencies = await extractDependencies(sourceFile.file.path)
     for (const dependency of dependencies) {
       const resolvedDependency = resolveDependency(
         dependency,

--- a/packages/steiger-plugin-fsd/src/no-cross-imports/index.ts
+++ b/packages/steiger-plugin-fsd/src/no-cross-imports/index.ts
@@ -22,7 +22,7 @@ const noCrossImports = {
       const sourceType = getSourceType(sourceFile.file.path)
       if (!sourceType) continue
 
-      const dependencies = await extractDependencies(sourceType, fs.readFileSync(sourceFile.file.path, 'utf8'))
+      const dependencies = await extractDependencies(sourceFile.file.path)
       for (const dependency of dependencies) {
         const resolvedDependency = resolveDependency(
           dependency,

--- a/packages/steiger-plugin-fsd/src/no-higher-level-imports/index.ts
+++ b/packages/steiger-plugin-fsd/src/no-higher-level-imports/index.ts
@@ -21,7 +21,7 @@ const noHigherLevelImports = {
       const sourceType = getSourceType(sourceFile.file.path)
       if (!sourceType) continue
 
-      const dependencies = await extractDependencies(sourceType, fs.readFileSync(sourceFile.file.path, 'utf8'))
+      const dependencies = await extractDependencies(sourceFile.file.path)
       for (const dependency of dependencies) {
         const resolvedDependency = resolveDependency(
           dependency,

--- a/packages/steiger-plugin-fsd/src/no-public-api-sidestep/index.ts
+++ b/packages/steiger-plugin-fsd/src/no-public-api-sidestep/index.ts
@@ -23,7 +23,7 @@ const noPublicApiSidestep = {
       const sourceType = getSourceType(sourceFile.file.path)
       if (!sourceType) continue
 
-      const dependencies = await extractDependencies(sourceType, fs.readFileSync(sourceFile.file.path, 'utf8'))
+      const dependencies = await extractDependencies(sourceFile.file.path)
       for (const dependency of dependencies) {
         const resolvedDependency = resolveDependency(
           dependency,

--- a/packages/toolkit/src/prepare-test.ts
+++ b/packages/toolkit/src/prepare-test.ts
@@ -1,5 +1,5 @@
 import { join, sep } from 'node:path'
-import type { readFileSync, existsSync } from 'node:fs'
+import type { readFileSync, existsSync, statSync } from 'node:fs'
 import type { Folder, File, PartialDiagnostic } from '@steiger/types'
 import { vi } from 'vitest'
 
@@ -68,6 +68,14 @@ export function createFsMocks(mockedFiles: Record<string, string>, original: typ
         (key) => key === normalizedPath || key.startsWith(normalizedPath + sep),
       )
     }) as typeof existsSync),
+    statSync: vi.fn(((path) => {
+      const normalizedPath = typeof path === 'string' ? path.replace(/\//g, sep) : path
+      if (typeof normalizedPath === 'string' && normalizedPath in normalizedMockedFiles) {
+        return { mtimeMs: 0 }
+      } else {
+        return original.statSync(normalizedPath)
+      }
+    }) as typeof statSync),
   } as typeof import('fs')
 }
 


### PR DESCRIPTION
Added fs cache for some of the most CPU-intensive rules, results:

before:
```
┌─────────┬────────────────────────────────────┬──────────┐
│ (index) │ Rule                               │ Duration │
├─────────┼────────────────────────────────────┼──────────┤
│ 0       │ 'fsd/no-public-api-sidestep'       │ 3187.31  │
│ 1       │ 'fsd/forbidden-imports'            │ 1739.14  │
│ 2       │ 'fsd/ambiguous-slice-names'        │ 206.61   │
│ 3       │ 'fsd/excessive-slicing'            │ 202.29   │
│ 4       │ 'fsd/insignificant-slice'          │ 127.33   │
│ 5       │ 'fsd/inconsistent-naming'          │ 126.87   │
│ 6       │ 'fsd/no-layer-public-api'          │ 110.27   │
│ 7       │ 'fsd/no-reserved-folder-names'     │ 56.74    │
│ 8       │ 'fsd/no-segmentless-slices'        │ 42.81    │
│ 9       │ 'fsd/no-segments-on-sliced-layers' │ 40.95    │
│ 10      │ 'fsd/no-ui-in-app'                 │ 39.92    │
│ 11      │ 'fsd/public-api'                   │ 38.94    │
│ 12      │ 'fsd/repetitive-naming'            │ 37.02    │
│ 13      │ 'fsd/segments-by-purpose'          │ 4.77     │
│ 14      │ 'fsd/shared-lib-grouping'          │ 2.88     │
│ 15      │ 'fsd/typo-in-layer-name'           │ 2.06     │
│ 16      │ 'fsd/no-processes'                 │ 0.99     │
└─────────┴────────────────────────────────────┴──────────┘

________________________________________________________
Executed in    5.36 secs    fish           external
   usr time    5.86 secs    0.00 micros    5.86 secs
   sys time    0.94 secs  464.00 micros    0.94 secs
``` 

after:
```
┌─────────┬────────────────────────────────────┬──────────┐
│ (index) │ Rule                               │ Duration │
├─────────┼────────────────────────────────────┼──────────┤
│ 0       │ 'fsd/no-public-api-sidestep'       │ 2228.52  │
│ 1       │ 'fsd/forbidden-imports'            │ 1749.35  │
│ 2       │ 'fsd/ambiguous-slice-names'        │ 203.91   │
│ 3       │ 'fsd/excessive-slicing'            │ 199.65   │
│ 4       │ 'fsd/insignificant-slice'          │ 128.58   │
│ 5       │ 'fsd/inconsistent-naming'          │ 128      │
│ 6       │ 'fsd/no-layer-public-api'          │ 111.85   │
│ 7       │ 'fsd/no-reserved-folder-names'     │ 59.04    │
│ 8       │ 'fsd/no-segmentless-slices'        │ 44.35    │
│ 9       │ 'fsd/no-segments-on-sliced-layers' │ 42.51    │
│ 10      │ 'fsd/no-ui-in-app'                 │ 41.48    │
│ 11      │ 'fsd/public-api'                   │ 40.49    │
│ 12      │ 'fsd/repetitive-naming'            │ 38.65    │
│ 13      │ 'fsd/segments-by-purpose'          │ 4.73     │
│ 14      │ 'fsd/shared-lib-grouping'          │ 2.86     │
│ 15      │ 'fsd/typo-in-layer-name'           │ 2.03     │
│ 16      │ 'fsd/no-processes'                 │ 1        │
└─────────┴────────────────────────────────────┴──────────┘

________________________________________________________
Executed in    4.41 secs    fish           external
   usr time    4.86 secs  240.00 micros    4.85 secs
   sys time    0.90 secs  146.00 micros    0.90 secs
```

I used the yeahub-platform repository for testing