### PR TITLE
feat: watch file changes in watch mode

### DIFF
--- a/.changeset/crazy-walls-love.md
+++ b/.changeset/crazy-walls-love.md
@@ -1,0 +1,5 @@
+---
+'steiger': minor
+---
+
+watch file changes in watch mode

--- a/packages/steiger/src/app.ts
+++ b/packages/steiger/src/app.ts
@@ -1,6 +1,6 @@
 import { performance } from 'node:perf_hooks'
 import { Console } from 'node:console'
-import { createEffect, sample } from 'effector'
+import { createEffect, merge, sample } from 'effector'
 import { debounce, not } from 'patronum'
 import type { Config, Folder, Rule } from '@steiger/types'
 
@@ -82,7 +82,7 @@ export const linter = {
   watch: async (path: string) => {
     const { vfs, watcher } = await createWatcher(path)
 
-    const treeChanged = debounce(vfs.$tree, 500)
+    const treeChanged = debounce(merge([vfs.$tree, vfs.fileChanged]), 500)
     const runRulesFx = createEffect(runRules)
 
     sample({

--- a/packages/steiger/src/features/transfer-fs-to-vfs.ts
+++ b/packages/steiger/src/features/transfer-fs-to-vfs.ts
@@ -32,6 +32,10 @@ export async function createWatcher(path: string) {
     vfs.fileRemoved(join(path, relativePath))
   })
 
+  watcher.on('change', async (relativePath) => {
+    vfs.fileChanged(join(path, relativePath))
+  })
+
   return {
     vfs,
     watcher,

--- a/packages/steiger/src/models/vfs.ts
+++ b/packages/steiger/src/models/vfs.ts
@@ -71,7 +71,9 @@ export function createVfsRoot(rootPath: string) {
     }),
   )
 
-  return { $tree, fileAdded, fileRemoved }
+  const fileChanged = createEvent<string>()
+
+  return { $tree, fileAdded, fileRemoved, fileChanged }
 }
 
 if (import.meta.vitest) {
@@ -221,6 +223,18 @@ if (import.meta.vitest) {
           },
         ],
       })
+    })
+
+    it('emits a signal via fileChanged', () => {
+      const { $tree, fileAdded, fileChanged } = createVfsRoot(join('/', 'project', 'src'))
+
+      fileAdded(join('/', 'project', 'src', 'index.ts'))
+      const stateBefore = $tree.getState()
+
+      expect(() => fileChanged(join('/', 'project', 'src', 'index.ts'))).not.toThrow()
+
+      const stateAfter = $tree.getState()
+      expect(stateAfter).toEqual(stateBefore)
     })
   })
 }


### PR DESCRIPTION
- Add `fileChanged` event to vfs
- Run validations on `fileChanged` event

With new caching enabled, file watching is quite fast now, you can compare those results with results from [here](https://github.com/feature-sliced/steiger/pull/243). CPU-intensive rules are twice as fast in watch mode, compared to basic runs.

```
┌─────────┬────────────────────────────────────┬──────────┐
│ (index) │ Rule                               │ Duration │
├─────────┼────────────────────────────────────┼──────────┤
│ 0       │ 'fsd/no-public-api-sidestep'       │ 1221.36  │
│ 1       │ 'fsd/forbidden-imports'            │ 772.87   │
│ 2       │ 'fsd/ambiguous-slice-names'        │ 259.59   │
│ 3       │ 'fsd/excessive-slicing'            │ 253.76   │
│ 4       │ 'fsd/insignificant-slice'          │ 158.18   │
│ 5       │ 'fsd/inconsistent-naming'          │ 153.18   │
│ 6       │ 'fsd/no-layer-public-api'          │ 124.14   │
│ 7       │ 'fsd/no-reserved-folder-names'     │ 65.72    │
│ 8       │ 'fsd/no-segmentless-slices'        │ 60.37    │
│ 9       │ 'fsd/no-segments-on-sliced-layers' │ 56.8     │
│ 10      │ 'fsd/no-ui-in-app'                 │ 54.47    │
│ 11      │ 'fsd/public-api'                   │ 52.12    │
│ 12      │ 'fsd/repetitive-naming'            │ 48.91    │
│ 13      │ 'fsd/segments-by-purpose'          │ 10.36    │
│ 14      │ 'fsd/shared-lib-grouping'          │ 6.92     │
│ 15      │ 'fsd/typo-in-layer-name'           │ 4.64     │
│ 16      │ 'fsd/no-processes'                 │ 2.34     │
└─────────┴────────────────────────────────────┴──────────┘
```

This also might be useful for things like LSP implementation.