### PR TITLE
feat: add the no-wildcard-exports rule

### DIFF
--- a/.changeset/no-wildcard-exports.md
+++ b/.changeset/no-wildcard-exports.md
@@ -2,4 +2,4 @@
 '@feature-sliced/steiger-plugin': minor
 ---
 
-add the `no-wildcard-exports` rule, which forbids `export * from` in public APIs but allows `export * as ns from`. It is disabled by default.
+add the `no-wildcard-exports` rule, which forbids `export * from` and `export * as ns from` in public APIs. The rule is disabled by default.

--- a/.changeset/no-wildcard-exports.md
+++ b/.changeset/no-wildcard-exports.md
@@ -1,0 +1,5 @@
+---
+'@feature-sliced/steiger-plugin': minor
+---
+
+add the `no-wildcard-exports` rule, which forbids `export * from` in public APIs but allows `export * as ns from`. It is disabled by default.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Currently, Steiger is not extendable with more rules, though that will change in
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/typo-in-layer-name/README.md"><code>fsd/typo-in-layer-name</code></a></td> <td>Ensure that all layers are named without any typos.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-processes/README.md"><code>fsd/no-processes</code></a></td> <td>Discourage the use of the deprecated Processes layer.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/import-locality/README.md"><code>fsd/import-locality</code></a></td> <td>[disabled] Require that imports from the same slice be relative and imports from one slice to another be absolute.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-wildcard-exports/README.md"><code>fsd/no-wildcard-exports</code></a></td> <td>[disabled] Forbid wildcard re-exports (<code>export * from</code>) in public APIs.</td> </tr>
 </tbody>
 </table>
 

--- a/packages/steiger-plugin-fsd/src/_language-tools/cache.spec.ts
+++ b/packages/steiger-plugin-fsd/src/_language-tools/cache.spec.ts
@@ -1,0 +1,31 @@
+import { expect, it, vi } from 'vitest'
+
+import { createMockedNodeFs } from './mock-node-fs.js'
+
+const readPaths: string[] = []
+
+vi.mock('node:fs', async () => {
+  const mocked = await createMockedNodeFs({
+    '/src/module.ts': ["import './dependency'", "export * from './re-exported'"].join('\n'),
+  })
+
+  return {
+    ...mocked,
+    readFileSync: ((path: string, options: never) => {
+      readPaths.push(path)
+      return mocked.readFileSync(path, options)
+    }) as typeof mocked.readFileSync,
+  }
+})
+
+import { extractDependencies, extractReExports } from './index.js'
+
+it('parses a file once and serves its imports and re-exports from one analysis', async () => {
+  expect((await extractDependencies('/src/module.ts')).map((dependency) => dependency.path)).toEqual(['./dependency'])
+  expect((await extractReExports('/src/module.ts')).map((reExport) => reExport.source)).toEqual(['./re-exported'])
+
+  await extractDependencies('/src/module.ts')
+  await extractReExports('/src/module.ts')
+
+  expect(readPaths.filter((path) => path === '/src/module.ts')).toHaveLength(1)
+})

--- a/packages/steiger-plugin-fsd/src/_language-tools/index.ts
+++ b/packages/steiger-plugin-fsd/src/_language-tools/index.ts
@@ -2,7 +2,7 @@ import { join, extname, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { isBuiltin } from 'node:module'
 import { readFileSync } from 'node:fs'
-import { Parser, Query, Language, Range, type Tree } from 'web-tree-sitter'
+import { Parser, Query, Language, Range, type Node, type Tree } from 'web-tree-sitter'
 import { createFSCache } from '../_lib/fs-cache.js'
 
 // TODO: replace with import.meta.dirname when upgrading to nodejs 20/22
@@ -43,9 +43,10 @@ interface Extractor {
   extensions: string[]
   language: Language
   injections: Array<{ query: Query; lang: string }>
-  queries: Array<{ query: Query; type: 'static' | 'dynamic' }>
-  /** Matches `export * from` statements, capturing the whole statement as `@statement` and the module specifier as `@path`. */
-  wildcardExportQuery?: Query
+  /** Queries for the modules a file pulls in. `static`/`dynamic` describes how the module is loaded. */
+  importQueries: Array<{ query: Query; type: 'static' | 'dynamic' }>
+  /** Queries for the modules a file re-exports. Each one captures `@statement` and `@source`, and produces one `kind`. */
+  reExportQueries: Array<{ query: Query; kind: ReExportInfo['kind'] }>
 }
 
 const extractors: Array<Extractor> = [
@@ -53,9 +54,9 @@ const extractors: Array<Extractor> = [
     type: 'tsx',
     extensions: ['.tsx', '.jsx', '.ts', '.js', '.cjs', '.mjs'],
     language: tsx,
-    queries: [
+    importQueries: [
       {
-        query: new Query(tsx, '(import_statement source: (string (string_fragment) @path))'),
+        query: new Query(tsx, '(import_statement source: (string (string_fragment) @source))'),
         type: 'static',
       },
       {
@@ -66,7 +67,7 @@ const extractors: Array<Extractor> = [
               (variable_declarator
                 value: (call_expression
                   function: (identifier) @function.name (#eq? @function.name "require")
-                  arguments: (arguments (string (string_fragment) @path))))))`,
+                  arguments: (arguments (string (string_fragment) @source))))))`,
         ),
         type: 'static',
       },
@@ -75,7 +76,7 @@ const extractors: Array<Extractor> = [
           tsx,
           `(call_expression
            	function: (import)
-            arguments: (arguments (string (string_fragment) @path)))`,
+            arguments: (arguments (string (string_fragment) @source)))`,
         ),
         type: 'dynamic',
       },
@@ -86,22 +87,49 @@ const extractors: Array<Extractor> = [
             (expression_statement
               (call_expression
                 function: (identifier) @function.name (#eq? @function.name "require")
-           			arguments: (arguments (string (string_fragment) @path)))))
+           			arguments: (arguments (string (string_fragment) @source)))))
           `,
         ),
         type: 'dynamic',
       },
     ],
-    // Deliberately does not match `export * as ns from`: a namespace re-export adds one name to the
-    // module's exports rather than an unknown number of them.
-    wildcardExportQuery: new Query(tsx, '(export_statement "*" source: (string (string_fragment) @path)) @statement'),
+    reExportQueries: [
+      {
+        // `export * from '…'`. The `*` is a direct child here, which is what separates this from a
+        // namespace re-export, where the `*` sits inside a `namespace_export` node.
+        query: new Query(tsx, '(export_statement "*" source: (string (string_fragment) @source)) @statement'),
+        kind: 'all',
+      },
+      {
+        // `export * as ns from '…'`
+        query: new Query(
+          tsx,
+          `(export_statement
+            (namespace_export (identifier) @exportedName)
+            source: (string (string_fragment) @source)) @statement`,
+        ),
+        kind: 'namespace',
+      },
+      {
+        // `export { a, b as c } from '…'`. Requiring `source` here is what keeps a local
+        // `export { a }`, which names no other module, out of the results.
+        query: new Query(
+          tsx,
+          `(export_statement
+            (export_clause) @clause
+            source: (string (string_fragment) @source)) @statement`,
+        ),
+        kind: 'named',
+      },
+    ],
     injections: [],
   },
   {
     type: 'svelte',
     extensions: ['.svelte'],
     language: svelte,
-    queries: [],
+    importQueries: [],
+    reExportQueries: [],
     injections: [
       {
         query: new Query(svelte, '(script_element (raw_text) @tsx)'),
@@ -113,7 +141,8 @@ const extractors: Array<Extractor> = [
     type: 'astro',
     extensions: ['.astro'],
     language: astro,
-    queries: [],
+    importQueries: [],
+    reExportQueries: [],
     injections: [
       {
         query: new Query(astro, '(frontmatter_js_block) @tsx'),
@@ -125,7 +154,8 @@ const extractors: Array<Extractor> = [
     type: 'vue',
     extensions: ['.vue'],
     language: vue,
-    queries: [],
+    importQueries: [],
+    reExportQueries: [],
     injections: [
       {
         query: new Query(vue, '(document (script_element (raw_text) @tsx))'),
@@ -146,26 +176,41 @@ export function getSourceType(sourcePath: string): string | undefined {
   return undefined
 }
 
-function processExtractor(extractor: Extractor, tree: Tree): Dependency[] {
-  const result: Dependency[] = []
+function rangeOf(node: Node): SourceRange {
+  return {
+    start: { line: node.startPosition.row + 1, column: node.startPosition.column + 1 },
+    end: { line: node.endPosition.row + 1, column: node.endPosition.column + 1 },
+  }
+}
 
-  for (const { query, type } of extractor.queries) {
-    const matches = query.matches(tree.rootNode)
-    for (const match of matches) {
+function readSpecifiers(clause: Node): NamedReExport['specifiers'] {
+  const specifiers: NamedReExport['specifiers'] = []
+
+  for (const child of clause.namedChildren) {
+    if (child.type !== 'export_specifier') continue
+
+    const name = child.childForFieldName('name')
+    if (name === null) continue
+
+    const alias = child.childForFieldName('alias')
+    specifiers.push(alias === null ? { name: name.text } : { name: name.text, alias: alias.text })
+  }
+
+  return specifiers
+}
+
+function collectImports(extractor: Extractor, tree: Tree): ImportInfo[] {
+  const result: ImportInfo[] = []
+
+  for (const { query, type } of extractor.importQueries) {
+    for (const match of query.matches(tree.rootNode)) {
       for (const capture of match.captures) {
-        if (capture.name === 'path') {
+        if (capture.name === 'source') {
           result.push({
+            source: capture.node.text,
             builtIn: isBuiltin(capture.node.text),
-            path: capture.node.text,
             dynamic: type === 'dynamic',
-            start: {
-              line: capture.node.startPosition.row + 1,
-              column: capture.node.startPosition.column + 1,
-            },
-            end: {
-              line: capture.node.endPosition.row + 1,
-              column: capture.node.endPosition.column + 1,
-            },
+            sourceRange: rangeOf(capture.node),
           })
         }
       }
@@ -175,36 +220,44 @@ function processExtractor(extractor: Extractor, tree: Tree): Dependency[] {
   return result
 }
 
-function processWildcardExports(extractor: Extractor, tree: Tree): WildcardExport[] {
-  if (extractor.wildcardExportQuery === undefined) return []
+function collectReExports(extractor: Extractor, tree: Tree): ReExportInfo[] {
+  const result: ReExportInfo[] = []
 
-  const result: WildcardExport[] = []
+  for (const { query, kind } of extractor.reExportQueries) {
+    for (const match of query.matches(tree.rootNode)) {
+      const captures = new Map(match.captures.map((capture) => [capture.name, capture.node]))
 
-  for (const match of extractor.wildcardExportQuery.matches(tree.rootNode)) {
-    const pathCapture = match.captures.find((capture) => capture.name === 'path')
-    const statementCapture = match.captures.find((capture) => capture.name === 'statement')
-    if (pathCapture === undefined || statementCapture === undefined) continue
+      const statement = captures.get('statement')
+      const source = captures.get('source')
+      if (statement === undefined || source === undefined) continue
 
-    result.push({
-      path: pathCapture.node.text,
-      start: {
-        line: statementCapture.node.startPosition.row + 1,
-        column: statementCapture.node.startPosition.column + 1,
-      },
-      end: {
-        line: statementCapture.node.endPosition.row + 1,
-        column: statementCapture.node.endPosition.column + 1,
-      },
-    })
+      const common = {
+        source: source.text,
+        sourceRange: rangeOf(source),
+        statementRange: rangeOf(statement),
+      }
+
+      if (kind === 'all') {
+        result.push({ kind, ...common })
+      } else if (kind === 'namespace') {
+        const exportedName = captures.get('exportedName')
+        if (exportedName === undefined) continue
+
+        result.push({ kind, exportedName: exportedName.text, ...common })
+      } else {
+        const clause = captures.get('clause')
+        if (clause === undefined) continue
+
+        result.push({ kind, specifiers: readSpecifiers(clause), ...common })
+      }
+    }
   }
 
   return result
 }
 
-interface WildcardExport {
-  /** The module specifier that the names are re-exported from. */
-  path: string
-  // all indexes are 1-based, and they span the whole `export * from` statement
+/** A span in a source file. All indexes are 1-based. */
+export interface SourceRange {
   start: {
     line: number
     column: number
@@ -215,39 +268,76 @@ interface WildcardExport {
   }
 }
 
-interface Dependency {
-  path: string
+export interface ImportInfo {
+  /** The module specifier, exactly as it is written in the source. */
+  source: string
   builtIn: boolean
   dynamic: boolean
-  // all indexes are 1-based
-  start: {
-    line: number
-    column: number
-  }
-  end: {
-    line: number
-    column: number
-  }
+  /** The specifier string on its own, which is the part that import diagnostics point at. */
+  sourceRange: SourceRange
+}
+
+/** `export * from '…'`, which passes on an unknown set of names. */
+export interface WildcardReExport {
+  kind: 'all'
+  source: string
+  sourceRange: SourceRange
+  statementRange: SourceRange
+}
+
+/** `export * as ns from '…'`, which passes on an unknown set of names, bound to a single identifier. */
+export interface NamespaceReExport {
+  kind: 'namespace'
+  source: string
+  /** The name the re-exported module is bound to, `ns` in `export * as ns from '…'`. */
+  exportedName: string
+  sourceRange: SourceRange
+  statementRange: SourceRange
+}
+
+/** `export { a, b as c } from '…'`. */
+export interface NamedReExport {
+  kind: 'named'
+  source: string
+  specifiers: Array<{ name: string; alias?: string }>
+  sourceRange: SourceRange
+  statementRange: SourceRange
+}
+
+export type ReExportInfo = WildcardReExport | NamespaceReExport | NamedReExport
+
+/**
+ * The other modules that a file names, both the ones it imports and the ones it re-exports.
+ *
+ * `reExports` holds the statements that name another module, and only those. The exports a module
+ * declares itself (`export const a = 1`, `export default a`, `export { a }`, and whatever a
+ * framework adds on top of a component file) are a different question that no rule asks yet, so
+ * this does not model them. A field for them can sit beside this one when a rule needs it.
+ */
+export interface ModuleAnalysis {
+  imports: ImportInfo[]
+  reExports: ReExportInfo[]
 }
 
 /**
- * Parse a source file and run `process` on its syntax tree, as well as on the syntax trees of the
+ * Parse a source file and run `visit` on its syntax tree, as well as on the syntax tree of the
  * languages injected into it (for example, the `<script>` block of a Vue component).
+ *
+ * Every injected region of a file is parsed into a single tree, so a Vue component that has both a
+ * `<script>` and a `<script setup>` block is analyzed as one module rather than two.
  */
-function processSourceFile<T>(path: string, process: (extractor: Extractor, tree: Tree) => Array<T>): Array<T> {
+function forEachSyntaxTree(path: string, visit: (extractor: Extractor, tree: Tree) => void): void {
   const extension = extname(path)
   const extractor = extractors.find((extractor) => extractor.extensions.includes(extension))
   if (!extractor) throw new Error(`No extractor found for "${extension}"`)
-
-  const results: Array<T> = []
 
   const sourceCode = readFileSync(path, 'utf8')
   const parser = new Parser()
   parser.setLanguage(extractor.language)
   const tree = parser.parse(sourceCode)
-  if (tree === null) return []
+  if (tree === null) return
 
-  results.push(...process(extractor, tree))
+  visit(extractor, tree)
 
   for (const { query, lang } of extractor.injections) {
     const injectedExtractor = extractors.find((extractor) => extractor.type === lang)
@@ -272,21 +362,76 @@ function processSourceFile<T>(path: string, process: (extractor: Extractor, tree
     parser.setLanguage(injectedExtractor.language)
     const injectedTree = parser.parse(sourceCode, null, { includedRanges })
     if (injectedTree === null) continue
-    results.push(...process(injectedExtractor, injectedTree))
+    visit(injectedExtractor, injectedTree)
     injectedTree.delete()
   }
 
   tree.delete()
-
-  return results
 }
 
-const cache = createFSCache<Dependency[]>()
-
-function extractAllDependencies(path: string): Dependency[] {
-  return processSourceFile(path, processExtractor)
+function comparePositions(a: SourceRange, b: SourceRange): number {
+  return a.start.line - b.start.line || a.start.column - b.start.column
 }
 
+function analyzeSourceFile(path: string): ModuleAnalysis {
+  const imports: ImportInfo[] = []
+  const reExports: ReExportInfo[] = []
+
+  forEachSyntaxTree(path, (extractor, tree) => {
+    imports.push(...collectImports(extractor, tree))
+    reExports.push(...collectReExports(extractor, tree))
+  })
+
+  // Queries run one after another, and injected trees come after the outer one, so matches arrive
+  // grouped by query rather than in reading order. Sorting keeps diagnostics readable: an index file
+  // that mixes `export *` with `export * as ns` would otherwise report its second line first.
+  imports.sort((a, b) => comparePositions(a.sourceRange, b.sourceRange))
+  reExports.sort((a, b) => comparePositions(a.statementRange, b.statementRange))
+
+  return { imports, reExports }
+}
+
+const moduleAnalysisCache = createFSCache<ModuleAnalysis>()
+
+/**
+ * Analyze what a module imports and what it re-exports.
+ *
+ * This parses a file once and caches the whole analysis, so rules that need different parts of it
+ * share the work. Callers filter what they get back; the cache always holds everything.
+ *
+ * Both lists are in source order.
+ */
+export async function analyzeModule(path: string): Promise<ModuleAnalysis> {
+  let analysis = moduleAnalysisCache.get(path)
+  if (!analysis) {
+    analysis = analyzeSourceFile(path)
+    moduleAnalysisCache.set(path, analysis)
+  }
+
+  return analysis
+}
+
+interface Dependency {
+  path: string
+  builtIn: boolean
+  dynamic: boolean
+  // all indexes are 1-based
+  start: {
+    line: number
+    column: number
+  }
+  end: {
+    line: number
+    column: number
+  }
+}
+
+/**
+ * Find the modules that a file imports.
+ *
+ * Re-exports are left out, since a rule asking what a file uses does not want its public API back.
+ * Rules that need re-exports read {@link extractReExports} instead.
+ */
 export async function extractDependencies(
   path: string,
   options?: {
@@ -297,35 +442,26 @@ export async function extractDependencies(
   const includeBuiltIns = options?.includeBuiltIns ?? false
   const importType = options?.importType
 
-  let dependencies = cache.get(path)
-  if (!dependencies) {
-    dependencies = extractAllDependencies(path)
-    cache.set(path, dependencies)
-  }
+  const { imports } = await analyzeModule(path)
 
-  return dependencies.filter((dep) => {
-    if (includeBuiltIns === false && dep.builtIn === true) return false
-    if (importType === 'dynamic' && dep.dynamic === false) return false
-    if (importType === 'static' && dep.dynamic === true) return false
+  return imports
+    .filter((moduleImport) => {
+      if (includeBuiltIns === false && moduleImport.builtIn === true) return false
+      if (importType === 'dynamic' && moduleImport.dynamic === false) return false
+      if (importType === 'static' && moduleImport.dynamic === true) return false
 
-    return true
-  })
+      return true
+    })
+    .map((moduleImport) => ({
+      path: moduleImport.source,
+      builtIn: moduleImport.builtIn,
+      dynamic: moduleImport.dynamic,
+      start: moduleImport.sourceRange.start,
+      end: moduleImport.sourceRange.end,
+    }))
 }
 
-const wildcardExportCache = createFSCache<WildcardExport[]>()
-
-/**
- * Find the wildcard re-exports (`export * from`) in a file.
- *
- * Namespace re-exports (`export * as ns from`) are not reported. They add one name to the module's
- * exports, so they don't hide what the module exports.
- */
-export async function extractWildcardExports(path: string): Promise<WildcardExport[]> {
-  let wildcardExports = wildcardExportCache.get(path)
-  if (!wildcardExports) {
-    wildcardExports = processSourceFile(path, processWildcardExports)
-    wildcardExportCache.set(path, wildcardExports)
-  }
-
-  return wildcardExports
+/** Find the modules that a file re-exports, in source order. */
+export async function extractReExports(path: string): Promise<ReExportInfo[]> {
+  return (await analyzeModule(path)).reExports
 }

--- a/packages/steiger-plugin-fsd/src/_language-tools/index.ts
+++ b/packages/steiger-plugin-fsd/src/_language-tools/index.ts
@@ -44,6 +44,8 @@ interface Extractor {
   language: Language
   injections: Array<{ query: Query; lang: string }>
   queries: Array<{ query: Query; type: 'static' | 'dynamic' }>
+  /** Matches `export * from` statements, capturing the whole statement as `@statement` and the module specifier as `@path`. */
+  wildcardExportQuery?: Query
 }
 
 const extractors: Array<Extractor> = [
@@ -90,6 +92,9 @@ const extractors: Array<Extractor> = [
         type: 'dynamic',
       },
     ],
+    // Deliberately does not match `export * as ns from`: a namespace re-export adds one name to the
+    // module's exports rather than an unknown number of them.
+    wildcardExportQuery: new Query(tsx, '(export_statement "*" source: (string (string_fragment) @path)) @statement'),
     injections: [],
   },
   {
@@ -170,6 +175,46 @@ function processExtractor(extractor: Extractor, tree: Tree): Dependency[] {
   return result
 }
 
+function processWildcardExports(extractor: Extractor, tree: Tree): WildcardExport[] {
+  if (extractor.wildcardExportQuery === undefined) return []
+
+  const result: WildcardExport[] = []
+
+  for (const match of extractor.wildcardExportQuery.matches(tree.rootNode)) {
+    const pathCapture = match.captures.find((capture) => capture.name === 'path')
+    const statementCapture = match.captures.find((capture) => capture.name === 'statement')
+    if (pathCapture === undefined || statementCapture === undefined) continue
+
+    result.push({
+      path: pathCapture.node.text,
+      start: {
+        line: statementCapture.node.startPosition.row + 1,
+        column: statementCapture.node.startPosition.column + 1,
+      },
+      end: {
+        line: statementCapture.node.endPosition.row + 1,
+        column: statementCapture.node.endPosition.column + 1,
+      },
+    })
+  }
+
+  return result
+}
+
+interface WildcardExport {
+  /** The module specifier that the names are re-exported from. */
+  path: string
+  // all indexes are 1-based, and they span the whole `export * from` statement
+  start: {
+    line: number
+    column: number
+  }
+  end: {
+    line: number
+    column: number
+  }
+}
+
 interface Dependency {
   path: string
   builtIn: boolean
@@ -185,14 +230,16 @@ interface Dependency {
   }
 }
 
-const cache = createFSCache<Dependency[]>()
-
-function extractAllDependencies(path: string): Dependency[] {
+/**
+ * Parse a source file and run `process` on its syntax tree, as well as on the syntax trees of the
+ * languages injected into it (for example, the `<script>` block of a Vue component).
+ */
+function processSourceFile<T>(path: string, process: (extractor: Extractor, tree: Tree) => Array<T>): Array<T> {
   const extension = extname(path)
   const extractor = extractors.find((extractor) => extractor.extensions.includes(extension))
   if (!extractor) throw new Error(`No extractor found for "${extension}"`)
 
-  const dependencies: Dependency[] = []
+  const results: Array<T> = []
 
   const sourceCode = readFileSync(path, 'utf8')
   const parser = new Parser()
@@ -200,7 +247,7 @@ function extractAllDependencies(path: string): Dependency[] {
   const tree = parser.parse(sourceCode)
   if (tree === null) return []
 
-  dependencies.push(...processExtractor(extractor, tree))
+  results.push(...process(extractor, tree))
 
   for (const { query, lang } of extractor.injections) {
     const injectedExtractor = extractors.find((extractor) => extractor.type === lang)
@@ -225,13 +272,19 @@ function extractAllDependencies(path: string): Dependency[] {
     parser.setLanguage(injectedExtractor.language)
     const injectedTree = parser.parse(sourceCode, null, { includedRanges })
     if (injectedTree === null) continue
-    dependencies.push(...processExtractor(injectedExtractor, injectedTree))
+    results.push(...process(injectedExtractor, injectedTree))
     injectedTree.delete()
   }
 
   tree.delete()
 
-  return dependencies
+  return results
+}
+
+const cache = createFSCache<Dependency[]>()
+
+function extractAllDependencies(path: string): Dependency[] {
+  return processSourceFile(path, processExtractor)
 }
 
 export async function extractDependencies(
@@ -257,4 +310,22 @@ export async function extractDependencies(
 
     return true
   })
+}
+
+const wildcardExportCache = createFSCache<WildcardExport[]>()
+
+/**
+ * Find the wildcard re-exports (`export * from`) in a file.
+ *
+ * Namespace re-exports (`export * as ns from`) are not reported. They add one name to the module's
+ * exports, so they don't hide what the module exports.
+ */
+export async function extractWildcardExports(path: string): Promise<WildcardExport[]> {
+  let wildcardExports = wildcardExportCache.get(path)
+  if (!wildcardExports) {
+    wildcardExports = processSourceFile(path, processWildcardExports)
+    wildcardExportCache.set(path, wildcardExports)
+  }
+
+  return wildcardExports
 }

--- a/packages/steiger-plugin-fsd/src/_language-tools/typescript.spec.ts
+++ b/packages/steiger-plugin-fsd/src/_language-tools/typescript.spec.ts
@@ -15,24 +15,37 @@ vi.mock('node:fs', () =>
       const isEven = await import('is-even')
     }
   `,
+    '/src/imports.ts': [
+      "import './bare'",
+      "import Default from './default'",
+      "import * as ns from './namespace'",
+      "import { foo as bar } from './named'",
+      "import type { Foo } from './types'",
+      "import('./dynamic')",
+      "require('./cjs')",
+    ].join('\n'),
     '/src/wildcard-exports.ts': [
       "export * from './model'",
-      'export * from "./ui";',
       "export type * from './types'",
+      "export * as ui from './ui'",
+      "export type * as api from './api'",
     ].join('\n'),
-    '/src/explicit-exports.ts': [
-      "export * as model from './model'",
-      "export type * as types from './types'",
-      "export { User, type UserData } from './model'",
-      "export { Button } from './ui'",
-      "import * as model from './model'",
-      'export const version = 1',
-      'export default version',
+    '/src/explicit-re-exports.ts': [
+      "export { foo } from './foo'",
+      "export { foo as bar } from './bar'",
+      "export { type Foo } from './types'",
+      "export { default as Baz } from './baz'",
+    ].join('\n'),
+    '/src/local-exports.ts': ['export const foo = 1', 'export default foo', 'export { foo }'].join('\n'),
+    '/src/ordering.ts': [
+      "const first = require('./first')",
+      "import second from './second'",
+      "export * from './third'",
     ].join('\n'),
   }),
 )
 
-import { extractDependencies, extractWildcardExports } from './index.js'
+import { analyzeModule, extractDependencies, extractReExports } from './index.js'
 
 it('extracts esm dependencies from TypeScript source code', async () => {
   const dependencies = await extractDependencies('/src/esm.tsx')
@@ -55,14 +68,108 @@ it('extracts dynamic dependencies from TypeScript source code', async () => {
   ])
 })
 
-it('extracts wildcard re-exports from TypeScript source code', async () => {
-  expect(await extractWildcardExports('/src/wildcard-exports.ts')).toEqual([
-    { path: './model', start: { line: 1, column: 1 }, end: { line: 1, column: 24 } },
-    { path: './ui', start: { line: 2, column: 1 }, end: { line: 2, column: 22 } },
-    { path: './types', start: { line: 3, column: 1 }, end: { line: 3, column: 29 } },
+it('extracts every form of import', async () => {
+  expect(await extractDependencies('/src/imports.ts')).toEqual([
+    { path: './bare', builtIn: false, dynamic: false, start: { line: 1, column: 9 }, end: { line: 1, column: 15 } },
+    { path: './default', builtIn: false, dynamic: false, start: { line: 2, column: 22 }, end: { line: 2, column: 31 } },
+    {
+      path: './namespace',
+      builtIn: false,
+      dynamic: false,
+      start: { line: 3, column: 22 },
+      end: { line: 3, column: 33 },
+    },
+    { path: './named', builtIn: false, dynamic: false, start: { line: 4, column: 29 }, end: { line: 4, column: 36 } },
+    { path: './types', builtIn: false, dynamic: false, start: { line: 5, column: 27 }, end: { line: 5, column: 34 } },
+    { path: './dynamic', builtIn: false, dynamic: true, start: { line: 6, column: 9 }, end: { line: 6, column: 18 } },
+    { path: './cjs', builtIn: false, dynamic: true, start: { line: 7, column: 10 }, end: { line: 7, column: 15 } },
   ])
 })
 
-it('does not report namespace re-exports or other export forms', async () => {
-  expect(await extractWildcardExports('/src/explicit-exports.ts')).toEqual([])
+it('extracts wildcard and namespace re-exports', async () => {
+  expect(await extractReExports('/src/wildcard-exports.ts')).toEqual([
+    {
+      kind: 'all',
+      source: './model',
+      sourceRange: { start: { line: 1, column: 16 }, end: { line: 1, column: 23 } },
+      statementRange: { start: { line: 1, column: 1 }, end: { line: 1, column: 24 } },
+    },
+    {
+      kind: 'all',
+      source: './types',
+      sourceRange: { start: { line: 2, column: 21 }, end: { line: 2, column: 28 } },
+      statementRange: { start: { line: 2, column: 1 }, end: { line: 2, column: 29 } },
+    },
+    {
+      kind: 'namespace',
+      source: './ui',
+      exportedName: 'ui',
+      sourceRange: { start: { line: 3, column: 22 }, end: { line: 3, column: 26 } },
+      statementRange: { start: { line: 3, column: 1 }, end: { line: 3, column: 27 } },
+    },
+    {
+      kind: 'namespace',
+      source: './api',
+      exportedName: 'api',
+      sourceRange: { start: { line: 4, column: 28 }, end: { line: 4, column: 33 } },
+      statementRange: { start: { line: 4, column: 1 }, end: { line: 4, column: 34 } },
+    },
+  ])
+})
+
+it('extracts explicit re-exports as named exports', async () => {
+  expect(await extractReExports('/src/explicit-re-exports.ts')).toEqual([
+    {
+      kind: 'named',
+      source: './foo',
+      specifiers: [{ name: 'foo' }],
+      sourceRange: { start: { line: 1, column: 22 }, end: { line: 1, column: 27 } },
+      statementRange: { start: { line: 1, column: 1 }, end: { line: 1, column: 28 } },
+    },
+    {
+      kind: 'named',
+      source: './bar',
+      specifiers: [{ name: 'foo', alias: 'bar' }],
+      sourceRange: { start: { line: 2, column: 29 }, end: { line: 2, column: 34 } },
+      statementRange: { start: { line: 2, column: 1 }, end: { line: 2, column: 35 } },
+    },
+    {
+      kind: 'named',
+      source: './types',
+      specifiers: [{ name: 'Foo' }],
+      sourceRange: { start: { line: 3, column: 27 }, end: { line: 3, column: 34 } },
+      statementRange: { start: { line: 3, column: 1 }, end: { line: 3, column: 35 } },
+    },
+    {
+      kind: 'named',
+      source: './baz',
+      specifiers: [{ name: 'default', alias: 'Baz' }],
+      sourceRange: { start: { line: 4, column: 33 }, end: { line: 4, column: 38 } },
+      statementRange: { start: { line: 4, column: 1 }, end: { line: 4, column: 39 } },
+    },
+  ])
+})
+
+it('ignores the exports a module declares itself, since they name no other module', async () => {
+  expect(await extractReExports('/src/local-exports.ts')).toEqual([])
+})
+
+// The bundled tree-sitter grammar has no rule for `export … with { … }`: such a statement parses as
+// a labeled statement, so it never reaches the re-export queries. Nothing in the extractor works
+// around that, and this should start passing on its own once the grammar gains the rule.
+it.todo('extracts a wildcard re-export that carries import attributes')
+
+it('returns imports and re-exports in source order', async () => {
+  const analysis = await analyzeModule('/src/ordering.ts')
+
+  // `require` is matched by a later query than `import`, so without sorting `./second` would come first.
+  expect(analysis.imports.map((moduleImport) => moduleImport.source)).toEqual(['./first', './second'])
+  expect(analysis.reExports.map((reExport) => reExport.source)).toEqual(['./third'])
+})
+
+it('leaves re-exports out of the imports of a module', async () => {
+  expect((await extractDependencies('/src/ordering.ts')).map((dependency) => dependency.path)).toEqual([
+    './first',
+    './second',
+  ])
 })

--- a/packages/steiger-plugin-fsd/src/_language-tools/typescript.spec.ts
+++ b/packages/steiger-plugin-fsd/src/_language-tools/typescript.spec.ts
@@ -15,10 +15,24 @@ vi.mock('node:fs', () =>
       const isEven = await import('is-even')
     }
   `,
+    '/src/wildcard-exports.ts': [
+      "export * from './model'",
+      'export * from "./ui";',
+      "export type * from './types'",
+    ].join('\n'),
+    '/src/explicit-exports.ts': [
+      "export * as model from './model'",
+      "export type * as types from './types'",
+      "export { User, type UserData } from './model'",
+      "export { Button } from './ui'",
+      "import * as model from './model'",
+      'export const version = 1',
+      'export default version',
+    ].join('\n'),
   }),
 )
 
-import { extractDependencies } from './index.js'
+import { extractDependencies, extractWildcardExports } from './index.js'
 
 it('extracts esm dependencies from TypeScript source code', async () => {
   const dependencies = await extractDependencies('/src/esm.tsx')
@@ -39,4 +53,16 @@ it('extracts dynamic dependencies from TypeScript source code', async () => {
   expect(dependencies).toEqual([
     { path: 'is-even', builtIn: false, dynamic: true, start: { line: 3, column: 36 }, end: { line: 3, column: 43 } },
   ])
+})
+
+it('extracts wildcard re-exports from TypeScript source code', async () => {
+  expect(await extractWildcardExports('/src/wildcard-exports.ts')).toEqual([
+    { path: './model', start: { line: 1, column: 1 }, end: { line: 1, column: 24 } },
+    { path: './ui', start: { line: 2, column: 1 }, end: { line: 2, column: 22 } },
+    { path: './types', start: { line: 3, column: 1 }, end: { line: 3, column: 29 } },
+  ])
+})
+
+it('does not report namespace re-exports or other export forms', async () => {
+  expect(await extractWildcardExports('/src/explicit-exports.ts')).toEqual([])
 })

--- a/packages/steiger-plugin-fsd/src/index.ts
+++ b/packages/steiger-plugin-fsd/src/index.ts
@@ -20,6 +20,7 @@ import packageJson from '../package.json' with { type: 'json' }
 import noCrossImports from './no-cross-imports/index.js'
 import noHigherLevelImports from './no-higher-level-imports/index.js'
 import importLocality from './import-locality/index.js'
+import noWildcardExports from './no-wildcard-exports/index.js'
 
 const enabledRules = [
   ambiguousSliceNames,
@@ -40,7 +41,7 @@ const enabledRules = [
   typoInLayerName,
   noProcesses,
 ]
-const disabledRules = [noCrossImports, noHigherLevelImports, importLocality]
+const disabledRules = [noCrossImports, noHigherLevelImports, importLocality, noWildcardExports]
 
 const rules = [...enabledRules, ...disabledRules]
 

--- a/packages/steiger-plugin-fsd/src/no-wildcard-exports/README.md
+++ b/packages/steiger-plugin-fsd/src/no-wildcard-exports/README.md
@@ -1,0 +1,53 @@
+# `no-wildcard-exports`
+
+Forbid wildcard re-exports (`export * from`) in public APIs.
+
+According to the _public API rule on slices_:
+
+> Every slice (and segment on layers that don't have slices) must contain a public API definition.
+>
+> Modules outside of this slice/segment can only reference the public API, not the internal file structure of the slice/segment.
+> https://feature-sliced.design/docs/reference/slices-segments#public-api-rule-on-slices
+
+The FSD documentation lists wildcard re-exports as bad practice:
+
+> This hurts the discoverability of a slice because you can't easily tell what the interface of this slice is.
+> https://feature-sliced.design/docs/reference/public-api#what-makes-a-good-public-api
+
+This rule checks every public API file on every layer, including index variants like `index.client.ts` and `index.server.ts`. It skips every other file, because a wildcard export inside a module stays private to the slice or segment that contains it.
+
+Namespace re-exports (`export * as ns from`) are allowed. They add one name to the public API, so a reader can still tell what the module exports.
+
+Examples of public APIs that pass this rule:
+
+```ts
+// entities/user/index.ts
+export { UserCard } from './ui/UserCard'
+export { type User, useUser } from './model/user'
+```
+
+```ts
+// shared/ui/index.ts
+export { Form, Field } from './form'
+export * as positions from './tooltip-positions'
+```
+
+Examples of public APIs that fail this rule:
+
+```ts
+// entities/user/index.ts
+export * from './ui/UserCard' // ❌
+export * from './model/user' // ❌
+```
+
+```ts
+// shared/ui/index.ts
+export { Form, Field } from './form'
+export * from './tooltip-positions' // ❌
+```
+
+## Rationale
+
+A wildcard re-export hides the public API of a group of modules, so you can't tell what a slice exports without opening every file inside it.
+
+It also lets the public API change by accident. Adding an export to an internal module adds it to the public API too, and removing that export later breaks whoever started using it. Listing the names means the public API only changes when someone edits the index file.

--- a/packages/steiger-plugin-fsd/src/no-wildcard-exports/README.md
+++ b/packages/steiger-plugin-fsd/src/no-wildcard-exports/README.md
@@ -1,6 +1,6 @@
 # `no-wildcard-exports`
 
-Forbid wildcard re-exports (`export * from`) in public APIs.
+Forbid wildcard re-exports (`export * from`, `export * as ns from`) in public APIs.
 
 According to the _public API rule on slices_:
 
@@ -16,7 +16,13 @@ The FSD documentation lists wildcard re-exports as bad practice:
 
 This rule checks every public API file on every layer, including index variants like `index.client.ts` and `index.server.ts`. It skips every other file, because a wildcard export inside a module stays private to the slice or segment that contains it.
 
-Namespace re-exports (`export * as ns from`) are allowed. They add one name to the public API, so a reader can still tell what the module exports.
+Namespace re-exports (`export * as ns from`) are reported too. The name in front only says where the re-exported names live, so the public API is still whatever the other module happens to export:
+
+```ts
+// entities/user/index.ts
+export * as model from './model'
+export * as ui from './ui'
+```
 
 Examples of public APIs that pass this rule:
 
@@ -29,7 +35,7 @@ export { type User, useUser } from './model/user'
 ```ts
 // shared/ui/index.ts
 export { Form, Field } from './form'
-export * as positions from './tooltip-positions'
+export { top, bottom } from './tooltip-positions'
 ```
 
 Examples of public APIs that fail this rule:
@@ -44,10 +50,11 @@ export * from './model/user' // ❌
 // shared/ui/index.ts
 export { Form, Field } from './form'
 export * from './tooltip-positions' // ❌
+export * as positions from './tooltip-positions' // ❌
 ```
 
 ## Rationale
 
-A wildcard re-export hides the public API of a group of modules, so you can't tell what a slice exports without opening every file inside it.
+A wildcard re-export hides the public API of a group of modules, so you can't tell what a slice exports without opening every file inside it. A namespace re-export moves the names behind a prefix but leaves the same question open.
 
 It also lets the public API change by accident. Adding an export to an internal module adds it to the public API too, and removing that export later breaks whoever started using it. Listing the names means the public API only changes when someone edits the index file.

--- a/packages/steiger-plugin-fsd/src/no-wildcard-exports/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-wildcard-exports/index.spec.ts
@@ -12,7 +12,7 @@ vi.mock('node:fs', async (importOriginal) => {
       // Public APIs that list everything they export
       '/src/shared/ui/index.ts': [
         "export { Button } from './Button'",
-        "export * as positions from './tooltip-positions'",
+        "export { top } from './tooltip-positions'",
       ].join('\n'),
       '/src/shared/ui/Button.tsx': 'export function Button() {}',
       '/src/shared/ui/tooltip-positions.ts': "export const top = 'top'",
@@ -43,6 +43,14 @@ vi.mock('node:fs', async (importOriginal) => {
       // Wildcard exports on the App layer
       '/src/app/index.ts': "export * from './providers'",
       '/src/app/providers.tsx': 'export function Providers() {}',
+
+      // A public API built only out of namespace re-exports
+      '/src/entities/order/index.ts': [
+        "export * as model from './model/order'",
+        "export * as ui from './ui/OrderCard'",
+      ].join('\n'),
+      '/src/entities/order/model/order.ts': 'export const order = {}',
+      '/src/entities/order/ui/OrderCard.tsx': 'export function OrderCard() {}',
 
       // A public API that mixes export kinds
       '/src/widgets/header/index.ts': [
@@ -146,7 +154,7 @@ it('reports wildcard exports in the public API of a slice', async () => {
 
   expect((await noWildcardExports.check(root)).diagnostics).toEqual([
     {
-      message: `Wildcard export from "./ui/ProductCard" hides the public API. List the exported names instead.`,
+      message: `Wildcard re-export from "./ui/ProductCard" does not define an explicit public API. Prefer explicit named exports.`,
       location: {
         path: joinFromRoot('src', 'entities', 'product', 'index.ts'),
         start: { line: 1, column: 1 },
@@ -154,7 +162,7 @@ it('reports wildcard exports in the public API of a slice', async () => {
       },
     },
     {
-      message: `Wildcard export from "./model/product" hides the public API. List the exported names instead.`,
+      message: `Wildcard re-export from "./model/product" does not define an explicit public API. Prefer explicit named exports.`,
       location: {
         path: joinFromRoot('src', 'entities', 'product', 'index.ts'),
         start: { line: 2, column: 1 },
@@ -180,7 +188,7 @@ it('reports wildcard exports on the Shared and App layers', async () => {
 
   expect((await noWildcardExports.check(root)).diagnostics.sort(compareMessages)).toEqual([
     {
-      message: `Wildcard export from "./format-date" hides the public API. List the exported names instead.`,
+      message: `Wildcard re-export from "./format-date" does not define an explicit public API. Prefer explicit named exports.`,
       location: {
         path: joinFromRoot('src', 'shared', 'lib', 'index.ts'),
         start: { line: 1, column: 1 },
@@ -188,7 +196,7 @@ it('reports wildcard exports on the Shared and App layers', async () => {
       },
     },
     {
-      message: `Wildcard export from "./providers" hides the public API. List the exported names instead.`,
+      message: `Wildcard re-export from "./providers" does not define an explicit public API. Prefer explicit named exports.`,
       location: {
         path: joinFromRoot('src', 'app', 'index.ts'),
         start: { line: 1, column: 1 },
@@ -198,7 +206,41 @@ it('reports wildcard exports on the Shared and App layers', async () => {
   ])
 })
 
-it('reports only the wildcard exports in a public API that mixes export kinds', async () => {
+it('reports a public API built only out of namespace re-exports', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 entities
+        📂 order
+          📂 ui
+            📄 OrderCard.tsx
+          📂 model
+            📄 order.ts
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await noWildcardExports.check(root)).diagnostics).toEqual([
+    {
+      message: `Wildcard re-export from "./model/order" does not define an explicit public API. Prefer explicit named exports.`,
+      location: {
+        path: joinFromRoot('src', 'entities', 'order', 'index.ts'),
+        start: { line: 1, column: 1 },
+        end: { line: 1, column: 39 },
+      },
+    },
+    {
+      message: `Wildcard re-export from "./ui/OrderCard" does not define an explicit public API. Prefer explicit named exports.`,
+      location: {
+        path: joinFromRoot('src', 'entities', 'order', 'index.ts'),
+        start: { line: 2, column: 1 },
+        end: { line: 2, column: 37 },
+      },
+    },
+  ])
+})
+
+it('reports the wildcard and namespace re-exports of a public API that mixes export kinds', async () => {
   const root = parseIntoFsdRoot(
     `
       📂 widgets
@@ -217,7 +259,7 @@ it('reports only the wildcard exports in a public API that mixes export kinds', 
 
   expect((await noWildcardExports.check(root)).diagnostics).toEqual([
     {
-      message: `Wildcard export from "./ui/Nav" hides the public API. List the exported names instead.`,
+      message: `Wildcard re-export from "./ui/Nav" does not define an explicit public API. Prefer explicit named exports.`,
       location: {
         path: joinFromRoot('src', 'widgets', 'header', 'index.ts'),
         start: { line: 2, column: 1 },
@@ -225,7 +267,15 @@ it('reports only the wildcard exports in a public API that mixes export kinds', 
       },
     },
     {
-      message: `Wildcard export from "./lib/use-scroll" hides the public API. List the exported names instead.`,
+      message: `Wildcard re-export from "./model/theme" does not define an explicit public API. Prefer explicit named exports.`,
+      location: {
+        path: joinFromRoot('src', 'widgets', 'header', 'index.ts'),
+        start: { line: 3, column: 1 },
+        end: { line: 3, column: 39 },
+      },
+    },
+    {
+      message: `Wildcard re-export from "./lib/use-scroll" does not define an explicit public API. Prefer explicit named exports.`,
       location: {
         path: joinFromRoot('src', 'widgets', 'header', 'index.ts'),
         start: { line: 5, column: 1 },
@@ -253,7 +303,7 @@ it('checks index file variants like index.client.ts and index.server.ts', async 
 
   expect((await noWildcardExports.check(root)).diagnostics).toEqual([
     {
-      message: `Wildcard export from "./ui/HomePage" hides the public API. List the exported names instead.`,
+      message: `Wildcard re-export from "./ui/HomePage" does not define an explicit public API. Prefer explicit named exports.`,
       location: {
         path: joinFromRoot('src', 'pages', 'home', 'index.client.ts'),
         start: { line: 1, column: 1 },
@@ -261,7 +311,7 @@ it('checks index file variants like index.client.ts and index.server.ts', async 
       },
     },
     {
-      message: `Wildcard export from "./api/errors" hides the public API. List the exported names instead.`,
+      message: `Wildcard re-export from "./api/errors" does not define an explicit public API. Prefer explicit named exports.`,
       location: {
         path: joinFromRoot('src', 'pages', 'home', 'index.server.ts'),
         start: { line: 2, column: 1 },
@@ -287,7 +337,7 @@ it('does not confuse a named export spread over several lines with a wildcard ex
 
   expect((await noWildcardExports.check(root)).diagnostics).toEqual([
     {
-      message: `Wildcard export from "./ui/LoginForm" hides the public API. List the exported names instead.`,
+      message: `Wildcard re-export from "./ui/LoginForm" does not define an explicit public API. Prefer explicit named exports.`,
       location: {
         path: joinFromRoot('src', 'features', 'auth', 'index.ts'),
         start: { line: 5, column: 1 },
@@ -313,7 +363,7 @@ it('checks the public API of a folder nested inside a segment', async () => {
 
   expect((await noWildcardExports.check(root)).diagnostics).toEqual([
     {
-      message: `Wildcard export from "./endpoints" hides the public API. List the exported names instead.`,
+      message: `Wildcard re-export from "./endpoints" does not define an explicit public API. Prefer explicit named exports.`,
       location: {
         path: joinFromRoot('src', 'shared', 'api', 'rest', 'index.ts'),
         start: { line: 1, column: 1 },

--- a/packages/steiger-plugin-fsd/src/no-wildcard-exports/index.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-wildcard-exports/index.spec.ts
@@ -1,0 +1,337 @@
+import { expect, it, vi } from 'vitest'
+
+import { compareMessages, joinFromRoot, parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
+import noWildcardExports from './index.js'
+
+vi.mock('node:fs', async (importOriginal) => {
+  const originalFs = await importOriginal<typeof import('fs')>()
+  const { createFsMocks } = await import('@steiger/toolkit/test')
+
+  return createFsMocks(
+    {
+      // Public APIs that list everything they export
+      '/src/shared/ui/index.ts': [
+        "export { Button } from './Button'",
+        "export * as positions from './tooltip-positions'",
+      ].join('\n'),
+      '/src/shared/ui/Button.tsx': 'export function Button() {}',
+      '/src/shared/ui/tooltip-positions.ts': "export const top = 'top'",
+      '/src/entities/user/index.ts': [
+        "export { UserCard } from './ui'",
+        "export { type User, useUser } from './model/user'",
+      ].join('\n'),
+      '/src/entities/user/ui/index.ts': "export { UserCard } from './UserCard'",
+      '/src/entities/user/ui/UserCard.tsx': 'export function UserCard() {}',
+      '/src/entities/user/model/user.ts': 'export function useUser() {}',
+
+      // A slice that wildcard-exports inside a module, but not in its public API
+      '/src/entities/session/index.ts': "export { useSession } from './model/session'",
+      '/src/entities/session/model/session.ts': "export * from './tokens'",
+      '/src/entities/session/model/tokens.ts': 'export const token = null',
+
+      // Wildcard exports in the public API of a slice
+      '/src/entities/product/index.ts': ["export * from './ui/ProductCard'", "export * from './model/product'"].join(
+        '\n',
+      ),
+      '/src/entities/product/ui/ProductCard.tsx': 'export function ProductCard() {}',
+      '/src/entities/product/model/product.ts': 'export const product = {}',
+
+      // Wildcard exports on the Shared layer
+      '/src/shared/lib/index.ts': "export * from './format-date'",
+      '/src/shared/lib/format-date.ts': 'export function formatDate() {}',
+
+      // Wildcard exports on the App layer
+      '/src/app/index.ts': "export * from './providers'",
+      '/src/app/providers.tsx': 'export function Providers() {}',
+
+      // A public API that mixes export kinds
+      '/src/widgets/header/index.ts': [
+        "export { Header } from './ui/Header'",
+        "export * from './ui/Nav'",
+        "export * as theme from './model/theme'",
+        "export type { HeaderProps } from './ui/Header'",
+        'export * from "./lib/use-scroll";',
+      ].join('\n'),
+      '/src/widgets/header/ui/Header.tsx': 'export function Header() {}',
+      '/src/widgets/header/ui/Nav.tsx': 'export function Nav() {}',
+      '/src/widgets/header/model/theme.ts': "export const theme = 'light'",
+      '/src/widgets/header/lib/use-scroll.ts': 'export function useScroll() {}',
+
+      // Index file variants are public APIs as well
+      '/src/pages/home/index.client.ts': "export * from './ui/HomePage'",
+      '/src/pages/home/index.server.ts': [
+        "export { loadHome } from './api/load-home'",
+        "export * from './api/errors'",
+      ].join('\n'),
+      '/src/pages/home/ui/HomePage.tsx': 'export function HomePage() {}',
+      '/src/pages/home/api/load-home.ts': 'export function loadHome() {}',
+      '/src/pages/home/api/errors.ts': 'export class LoadError extends Error {}',
+
+      // A public API spread over several lines
+      '/src/features/auth/index.ts': [
+        'export {',
+        '  useAuth,',
+        "} from './model/auth'",
+        '',
+        "export * from './ui/LoginForm'",
+      ].join('\n'),
+      '/src/features/auth/model/auth.ts': 'export function useAuth() {}',
+      '/src/features/auth/ui/LoginForm.tsx': 'export function LoginForm() {}',
+
+      // A public API nested inside a segment of the Shared layer
+      '/src/shared/api/index.ts': "export { client } from './client'",
+      '/src/shared/api/client.ts': 'export const client = {}',
+      '/src/shared/api/rest/index.ts': "export * from './endpoints'",
+      '/src/shared/api/rest/endpoints.ts': 'export const endpoints = {}',
+
+      // A public API that isn't source code
+      '/src/shared/styles/index.css': ':root {\n  color: red;\n}',
+    },
+    originalFs,
+  )
+})
+
+it('reports no errors when public APIs list their exports explicitly', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 shared
+        📂 ui
+          📄 Button.tsx
+          📄 tooltip-positions.ts
+          📄 index.ts
+      📂 entities
+        📂 user
+          📂 ui
+            📄 UserCard.tsx
+            📄 index.ts
+          📂 model
+            📄 user.ts
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await noWildcardExports.check(root)).diagnostics).toEqual([])
+})
+
+it('ignores wildcard exports in files that are not a public API', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 entities
+        📂 session
+          📂 model
+            📄 session.ts
+            📄 tokens.ts
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await noWildcardExports.check(root)).diagnostics).toEqual([])
+})
+
+it('reports wildcard exports in the public API of a slice', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 entities
+        📂 product
+          📂 ui
+            📄 ProductCard.tsx
+          📂 model
+            📄 product.ts
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await noWildcardExports.check(root)).diagnostics).toEqual([
+    {
+      message: `Wildcard export from "./ui/ProductCard" hides the public API. List the exported names instead.`,
+      location: {
+        path: joinFromRoot('src', 'entities', 'product', 'index.ts'),
+        start: { line: 1, column: 1 },
+        end: { line: 1, column: 33 },
+      },
+    },
+    {
+      message: `Wildcard export from "./model/product" hides the public API. List the exported names instead.`,
+      location: {
+        path: joinFromRoot('src', 'entities', 'product', 'index.ts'),
+        start: { line: 2, column: 1 },
+        end: { line: 2, column: 32 },
+      },
+    },
+  ])
+})
+
+it('reports wildcard exports on the Shared and App layers', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 shared
+        📂 lib
+          📄 format-date.ts
+          📄 index.ts
+      📂 app
+        📄 providers.tsx
+        📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await noWildcardExports.check(root)).diagnostics.sort(compareMessages)).toEqual([
+    {
+      message: `Wildcard export from "./format-date" hides the public API. List the exported names instead.`,
+      location: {
+        path: joinFromRoot('src', 'shared', 'lib', 'index.ts'),
+        start: { line: 1, column: 1 },
+        end: { line: 1, column: 30 },
+      },
+    },
+    {
+      message: `Wildcard export from "./providers" hides the public API. List the exported names instead.`,
+      location: {
+        path: joinFromRoot('src', 'app', 'index.ts'),
+        start: { line: 1, column: 1 },
+        end: { line: 1, column: 28 },
+      },
+    },
+  ])
+})
+
+it('reports only the wildcard exports in a public API that mixes export kinds', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 widgets
+        📂 header
+          📂 ui
+            📄 Header.tsx
+            📄 Nav.tsx
+          📂 model
+            📄 theme.ts
+          📂 lib
+            📄 use-scroll.ts
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await noWildcardExports.check(root)).diagnostics).toEqual([
+    {
+      message: `Wildcard export from "./ui/Nav" hides the public API. List the exported names instead.`,
+      location: {
+        path: joinFromRoot('src', 'widgets', 'header', 'index.ts'),
+        start: { line: 2, column: 1 },
+        end: { line: 2, column: 25 },
+      },
+    },
+    {
+      message: `Wildcard export from "./lib/use-scroll" hides the public API. List the exported names instead.`,
+      location: {
+        path: joinFromRoot('src', 'widgets', 'header', 'index.ts'),
+        start: { line: 5, column: 1 },
+        end: { line: 5, column: 34 },
+      },
+    },
+  ])
+})
+
+it('checks index file variants like index.client.ts and index.server.ts', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 pages
+        📂 home
+          📂 ui
+            📄 HomePage.tsx
+          📂 api
+            📄 load-home.ts
+            📄 errors.ts
+          📄 index.client.ts
+          📄 index.server.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await noWildcardExports.check(root)).diagnostics).toEqual([
+    {
+      message: `Wildcard export from "./ui/HomePage" hides the public API. List the exported names instead.`,
+      location: {
+        path: joinFromRoot('src', 'pages', 'home', 'index.client.ts'),
+        start: { line: 1, column: 1 },
+        end: { line: 1, column: 30 },
+      },
+    },
+    {
+      message: `Wildcard export from "./api/errors" hides the public API. List the exported names instead.`,
+      location: {
+        path: joinFromRoot('src', 'pages', 'home', 'index.server.ts'),
+        start: { line: 2, column: 1 },
+        end: { line: 2, column: 29 },
+      },
+    },
+  ])
+})
+
+it('does not confuse a named export spread over several lines with a wildcard export', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 features
+        📂 auth
+          📂 ui
+            📄 LoginForm.tsx
+          📂 model
+            📄 auth.ts
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await noWildcardExports.check(root)).diagnostics).toEqual([
+    {
+      message: `Wildcard export from "./ui/LoginForm" hides the public API. List the exported names instead.`,
+      location: {
+        path: joinFromRoot('src', 'features', 'auth', 'index.ts'),
+        start: { line: 5, column: 1 },
+        end: { line: 5, column: 31 },
+      },
+    },
+  ])
+})
+
+it('checks the public API of a folder nested inside a segment', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 shared
+        📂 api
+          📂 rest
+            📄 endpoints.ts
+            📄 index.ts
+          📄 client.ts
+          📄 index.ts
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await noWildcardExports.check(root)).diagnostics).toEqual([
+    {
+      message: `Wildcard export from "./endpoints" hides the public API. List the exported names instead.`,
+      location: {
+        path: joinFromRoot('src', 'shared', 'api', 'rest', 'index.ts'),
+        start: { line: 1, column: 1 },
+        end: { line: 1, column: 28 },
+      },
+    },
+  ])
+})
+
+it('skips public APIs that are not source code', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 shared
+        📂 styles
+          📄 index.css
+    `,
+    joinFromRoot('src'),
+  )
+
+  expect((await noWildcardExports.check(root)).diagnostics).toEqual([])
+})

--- a/packages/steiger-plugin-fsd/src/no-wildcard-exports/index.ts
+++ b/packages/steiger-plugin-fsd/src/no-wildcard-exports/index.ts
@@ -1,0 +1,37 @@
+import { isIndex } from '@feature-sliced/filesystem'
+import type { PartialDiagnostic, Rule } from '@steiger/toolkit'
+
+import { indexSourceFiles } from '../_lib/index-source-files.js'
+import { extractWildcardExports, getSourceType } from '../_language-tools/index.js'
+import { NAMESPACE } from '../constants.js'
+
+/** Forbid wildcard re-exports (`export * from`) in public APIs. */
+const noWildcardExports = {
+  name: `${NAMESPACE}/no-wildcard-exports` as const,
+  async check(root) {
+    const diagnostics: Array<PartialDiagnostic> = []
+
+    for (const sourceFile of Object.values(indexSourceFiles(root))) {
+      if (!isIndex(sourceFile.file)) continue
+
+      const sourceType = getSourceType(sourceFile.file.path)
+      if (!sourceType) continue
+
+      const wildcardExports = await extractWildcardExports(sourceFile.file.path)
+      for (const wildcardExport of wildcardExports) {
+        diagnostics.push({
+          message: `Wildcard export from "${wildcardExport.path}" hides the public API. List the exported names instead.`,
+          location: {
+            path: sourceFile.file.path,
+            start: wildcardExport.start,
+            end: wildcardExport.end,
+          },
+        })
+      }
+    }
+
+    return { diagnostics }
+  },
+} satisfies Rule
+
+export default noWildcardExports

--- a/packages/steiger-plugin-fsd/src/no-wildcard-exports/index.ts
+++ b/packages/steiger-plugin-fsd/src/no-wildcard-exports/index.ts
@@ -2,10 +2,10 @@ import { isIndex } from '@feature-sliced/filesystem'
 import type { PartialDiagnostic, Rule } from '@steiger/toolkit'
 
 import { indexSourceFiles } from '../_lib/index-source-files.js'
-import { extractWildcardExports, getSourceType } from '../_language-tools/index.js'
+import { extractReExports, getSourceType } from '../_language-tools/index.js'
 import { NAMESPACE } from '../constants.js'
 
-/** Forbid wildcard re-exports (`export * from`) in public APIs. */
+/** Forbid wildcard re-exports (`export * from`, `export * as ns from`) in public APIs. */
 const noWildcardExports = {
   name: `${NAMESPACE}/no-wildcard-exports` as const,
   async check(root) {
@@ -17,14 +17,15 @@ const noWildcardExports = {
       const sourceType = getSourceType(sourceFile.file.path)
       if (!sourceType) continue
 
-      const wildcardExports = await extractWildcardExports(sourceFile.file.path)
-      for (const wildcardExport of wildcardExports) {
+      for (const reExport of await extractReExports(sourceFile.file.path)) {
+        if (reExport.kind !== 'all' && reExport.kind !== 'namespace') continue
+
         diagnostics.push({
-          message: `Wildcard export from "${wildcardExport.path}" hides the public API. List the exported names instead.`,
+          message: `Wildcard re-export from "${reExport.source}" does not define an explicit public API. Prefer explicit named exports.`,
           location: {
             path: sourceFile.file.path,
-            start: wildcardExport.start,
-            end: wildcardExport.end,
+            start: reExport.statementRange.start,
+            end: reExport.statementRange.end,
           },
         })
       }

--- a/packages/steiger-plugin-fsd/src/no-wildcard-exports/real-fs.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-wildcard-exports/real-fs.spec.ts
@@ -32,7 +32,7 @@ await Promise.all([
   writeFile('src/entities/user/index.ts', "export * from './ui/UserCard'\n"),
 ])
 
-it('reports wildcard exports in a project on disk', async () => {
+it('reports wildcard and namespace re-exports in a project on disk', async () => {
   const root = parseIntoFsdRoot(
     `
       📂 shared
@@ -53,7 +53,15 @@ it('reports wildcard exports in a project on disk', async () => {
 
   expect((await noWildcardExports.check(root)).diagnostics).toEqual([
     {
-      message: `Wildcard export from "./ui/UserCard" hides the public API. List the exported names instead.`,
+      message: `Wildcard re-export from "./tooltip-positions" does not define an explicit public API. Prefer explicit named exports.`,
+      location: {
+        path: join(project, 'src', 'shared', 'ui', 'index.ts'),
+        start: { line: 2, column: 1 },
+        end: { line: 2, column: 49 },
+      },
+    },
+    {
+      message: `Wildcard re-export from "./ui/UserCard" does not define an explicit public API. Prefer explicit named exports.`,
       location: {
         path: join(project, 'src', 'entities', 'user', 'index.ts'),
         start: { line: 1, column: 1 },

--- a/packages/steiger-plugin-fsd/src/no-wildcard-exports/real-fs.spec.ts
+++ b/packages/steiger-plugin-fsd/src/no-wildcard-exports/real-fs.spec.ts
@@ -1,0 +1,64 @@
+import * as fs from 'node:fs/promises'
+import os from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterAll, expect, it } from 'vitest'
+
+import { parseIntoFolder as parseIntoFsdRoot } from '@steiger/toolkit/test'
+import noWildcardExports from './index.js'
+
+/**
+ * The other spec of this rule mocks `node:fs`. This one runs the rule against real files on disk, so
+ * the rule reads and parses the project the same way it does when Steiger runs.
+ */
+const project = await fs.mkdtemp(join(await fs.realpath(os.tmpdir()), 'no-wildcard-exports-'))
+
+afterAll(() => fs.rm(project, { recursive: true, force: true, maxRetries: 3 }))
+
+async function writeFile(relativePath: string, content: string) {
+  const path = join(project, ...relativePath.split('/'))
+  await fs.mkdir(dirname(path), { recursive: true })
+  await fs.writeFile(path, content, 'utf8')
+}
+
+await Promise.all([
+  writeFile('src/shared/ui/Button.tsx', 'export function Button() {}\n'),
+  writeFile('src/shared/ui/tooltip-positions.ts', "export const top = 'top'\n"),
+  writeFile(
+    'src/shared/ui/index.ts',
+    "export { Button } from './Button'\nexport * as positions from './tooltip-positions'\n",
+  ),
+  writeFile('src/entities/user/ui/UserCard.tsx', 'export function UserCard() {}\n'),
+  writeFile('src/entities/user/model/user.ts', "export * from './session'\n"),
+  writeFile('src/entities/user/index.ts', "export * from './ui/UserCard'\n"),
+])
+
+it('reports wildcard exports in a project on disk', async () => {
+  const root = parseIntoFsdRoot(
+    `
+      📂 shared
+        📂 ui
+          📄 Button.tsx
+          📄 tooltip-positions.ts
+          📄 index.ts
+      📂 entities
+        📂 user
+          📂 ui
+            📄 UserCard.tsx
+          📂 model
+            📄 user.ts
+          📄 index.ts
+    `,
+    join(project, 'src'),
+  )
+
+  expect((await noWildcardExports.check(root)).diagnostics).toEqual([
+    {
+      message: `Wildcard export from "./ui/UserCard" hides the public API. List the exported names instead.`,
+      location: {
+        path: join(project, 'src', 'entities', 'user', 'index.ts'),
+        start: { line: 1, column: 1 },
+        end: { line: 1, column: 30 },
+      },
+    },
+  ])
+})

--- a/packages/steiger/README.md
+++ b/packages/steiger/README.md
@@ -171,6 +171,7 @@ Currently, Steiger is not extendable with more rules, though that will change in
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/typo-in-layer-name/README.md"><code>typo-in-layer-name</code></a></td> <td>Ensure that all layers are named without any typos.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-processes/README.md"><code>no-processes</code></a></td> <td>Discourage the use of the deprecated Processes layer.</td> </tr>
   <tr> <td><a href="./packages/steiger-plugin-fsd/src/import-locality/README.md"><code>import-locality</code></a></td> <td>[disabled] Require that imports from the same slice be relative and imports from one slice to another be absolute.</td> </tr>
+  <tr> <td><a href="./packages/steiger-plugin-fsd/src/no-wildcard-exports/README.md"><code>no-wildcard-exports</code></a></td> <td>[disabled] Forbid wildcard re-exports (<code>export * from</code>) in public APIs.</td> </tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
# Background 

Added a `no-wildcard-exports` rule that detects wildcard re-exports in public APIs.

It reports the following patterns:

```ts
export * from "./foo";
export type * from "./foo";
export * as foo from "./foo";
export type * as foo from "./foo";
```

Explicit re-exports are still allowed:

```ts
export { foo } from "./foo";
export { foo as bar } from "./foo";
```

To support this, `_language-tools` was refactored to analyze imports and re-exports together and reuse the same FS cache. The behavior of existing import-based rules remains unchanged.
