### PR TITLE
fix(ci): remove the duplicate checkout from the setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,7 +17,5 @@ runs:
         node-version: ${{ inputs.node-version }}
         cache: 'pnpm'
 
-    - uses: actions/checkout@v4
-
     - shell: bash
       run: pnpm install


### PR DESCRIPTION
Removed the duplicate `actions/checkout` step from `.github/actions/setup`.

In the `bundle-size-untrusted` workflow, the base and head branches are checked out separately before running the setup action. However, the checkout inside the setup action was overwriting the selected ref, causing both jobs to build the same code. As a result, the Before and After values in the bundle size report were always the same.

All workflows that use the setup action already perform a checkout beforehand, so the checkout inside the action was unnecessary.

One thing to note is that the bundle size report for this PR itself may still not fully reflect the fix, because the base job will continue to use the existing setup action from the base branch. The comparison should work correctly for PRs opened after this change is merged.